### PR TITLE
[REM3-170] added test 

### DIFF
--- a/src/test/java/org/jboss/remoting3/test/MessageSizeLimitTest.java
+++ b/src/test/java/org/jboss/remoting3/test/MessageSizeLimitTest.java
@@ -95,7 +95,10 @@ public class MessageSizeLimitTest  {
         assertEquals("bob", serverChannel.getConnection().getUserInfo().getUserName());
     }
 
-
+    /**
+     * Clients sends message shorter than outbound size, it will be truncated on the receiving side.
+     * @throws Exception
+     */
     @Test
     public void testMessageSizeLimitOK() throws Exception {
         MessageOutputStream myOutputStream = null;


### PR DESCRIPTION
2 tests for new feature REM3-170. 
Test for outbound message size overflow.
Test for sending message shorter than outbound message size, but longer than inbound size: the message should be truncated and delivered.
