### PR TITLE
REM3-187

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,15 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.build.sourceDirectory}</directory>
+                <includes>
+                    <include>**/Version.properties</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.jboss.seven2six</groupId>

--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -67,7 +67,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
 
     static {
         // Print Remoting "greeting" message
-        Logger.getLogger("org.jboss.remoting").infof("JBoss Remoting version %s", Version.getVersionString());
+        Logger.getLogger("org.jboss.remoting").infof("JBoss Remoting version %s", Version.INSTANCE.toString());
     }
 
     private static final Logger log = Logger.getLogger("org.jboss.remoting.endpoint");

--- a/src/main/java/org/jboss/remoting3/Version.java
+++ b/src/main/java/org/jboss/remoting3/Version.java
@@ -22,89 +22,19 @@
 
 package org.jboss.remoting3;
 
-import static org.xnio.IoUtils.safeClose;
+import java.util.ResourceBundle;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.Enumeration;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
+public enum Version {
+  INSTANCE("version");
 
-/**
- * The version of Remoting.
- *
- * @apiviz.exclude
- */
-@SuppressWarnings("deprecation")
-public final class Version {
+  private static final ResourceBundle resource = ResourceBundle.getBundle(Version.class.getName());
+  private final String key;
 
-    private Version() {
-    }
+  private Version(String key) {
+    this.key = key;
+  }
 
-    private static final String JAR_NAME;
-    /**
-     * The version string.
-     *
-     * @deprecated Use {@link #getVersionString()} instead.
-     */
-    @Deprecated
-    public static final String VERSION;
-
-    static {
-        final Enumeration<URL> resources;
-        String jarName = "(unknown)";
-        String versionString = "(unknown)";
-        final ClassLoader classLoader = Version.class.getClassLoader();
-        try {
-            resources = classLoader == null ? ClassLoader.getSystemResources("META-INF/MANIFEST.MF") : classLoader.getResources("META-INF/MANIFEST.MF");
-            while (resources.hasMoreElements()) {
-                final URL url = resources.nextElement();
-                try {
-                    final InputStream stream = url.openStream();
-                    if (stream != null) try {
-                        final Manifest manifest = new Manifest(stream);
-                        final Attributes mainAttributes = manifest.getMainAttributes();
-                        if (mainAttributes != null && "JBoss Remoting".equals(mainAttributes.getValue("Specification-Title"))) {
-                            jarName = mainAttributes.getValue("Jar-Name");
-                            versionString = mainAttributes.getValue("Jar-Version");
-                        }
-                    } finally {
-                        safeClose(stream);
-                    }
-                } catch (IOException ignored) {
-                }
-            }
-        } catch (IOException ignored) {
-        }
-        JAR_NAME = jarName;
-        VERSION = versionString;
-    }
-
-    /**
-     * Get the name of the JBoss Remoting JAR.
-     *
-     * @return the name
-     */
-    public static String getJarName() {
-        return JAR_NAME;
-    }
-
-    /**
-     * Get the version string of JBoss Remoting.
-     *
-     * @return the version string
-     */
-    public static String getVersionString() {
-        return VERSION;
-    }
-
-    /**
-     * Print out the current version on {@code System.out}.
-     *
-     * @param args ignored
-     */
-    public static void main(String[] args) {
-        System.out.printf("JBoss Remoting version %s\n", getVersionString());
-    }
+  public String toString() {
+    return resource.getString(this.key);
+  }
 }

--- a/src/main/java/org/jboss/remoting3/Version.properties
+++ b/src/main/java/org/jboss/remoting3/Version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/main/java/org/jboss/remoting3/remote/ClientConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ClientConnectionOpenListener.java
@@ -127,7 +127,7 @@ final class ClientConnectionOpenListener implements ChannelListener<ConnectedMes
                 ProtocolUtils.writeString(sendBuffer, Protocol.CAP_ENDPOINT_NAME, localEndpointName);
             }
             ProtocolUtils.writeEmpty(sendBuffer, Protocol.CAP_MESSAGE_CLOSE);
-            ProtocolUtils.writeString(sendBuffer, Protocol.CAP_VERSION_STRING, Version.getVersionString());
+            ProtocolUtils.writeString(sendBuffer, Protocol.CAP_VERSION_STRING, Version.INSTANCE.toString());
             ProtocolUtils.writeInt(sendBuffer, Protocol.CAP_CHANNELS_IN, optionMap.get(RemotingOptions.MAX_INBOUND_CHANNELS, RemotingOptions.DEFAULT_MAX_INBOUND_CHANNELS));
             ProtocolUtils.writeInt(sendBuffer, Protocol.CAP_CHANNELS_OUT, optionMap.get(RemotingOptions.MAX_OUTBOUND_CHANNELS, RemotingOptions.DEFAULT_MAX_OUTBOUND_CHANNELS));
             sendBuffer.flip();

--- a/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
@@ -441,7 +441,7 @@ final class ServerConnectionOpenListener  implements ChannelListener<ConnectedMe
                     ProtocolUtils.writeString(sendBuffer, Protocol.CAP_SASL_MECH, mechName);
                 }
                 ProtocolUtils.writeEmpty(sendBuffer, Protocol.CAP_MESSAGE_CLOSE);
-                ProtocolUtils.writeString(sendBuffer, Protocol.CAP_VERSION_STRING, Version.getVersionString());
+                ProtocolUtils.writeString(sendBuffer, Protocol.CAP_VERSION_STRING, Version.INSTANCE.toString());
                 ProtocolUtils.writeInt(sendBuffer, Protocol.CAP_CHANNELS_IN, optionMap.get(RemotingOptions.MAX_INBOUND_CHANNELS, RemotingOptions.DEFAULT_MAX_INBOUND_CHANNELS));
                 ProtocolUtils.writeInt(sendBuffer, Protocol.CAP_CHANNELS_OUT, optionMap.get(RemotingOptions.MAX_OUTBOUND_CHANNELS, RemotingOptions.DEFAULT_MAX_OUTBOUND_CHANNELS));
                 sendBuffer.flip();


### PR DESCRIPTION
WDYT? Fix for: [REM3-187](https://issues.jboss.org/browse/REM3-187) The Version class looked a bit obsolete, so I propose this approach we have in mod_cluster subsystem project. The next step would be adding messages properties in order to comply with [ANDIAMO-7](https://issues.jboss.org/browse/ANDIAMO-7)

If you don't like the cut and the main method was actually used in some context unknown to me, shout and throw rocks.
