### PR TITLE
[REM3-192] Make the underlying SSLSession available from the Connection.

### DIFF
--- a/src/main/java/org/jboss/remoting3/Connection.java
+++ b/src/main/java/org/jboss/remoting3/Connection.java
@@ -25,6 +25,8 @@ package org.jboss.remoting3;
 import java.security.Principal;
 import java.util.Collection;
 
+import javax.net.ssl.SSLSession;
+
 import org.jboss.remoting3.security.UserInfo;
 import org.xnio.IoFuture;
 import org.xnio.OptionMap;
@@ -47,6 +49,13 @@ public interface Connection extends HandleableCloseable<Connection>, Attachable 
      * @return the authenticated UserInfo
      */
     UserInfo getUserInfo();
+
+    /**
+     * Get the underlying {@link SSLSession} for this connection if one is established.
+     *
+     * @return the {@link SSLSession} for the connection if one is established, otherwise returns {@code null}.
+     */
+    SSLSession getSslSession();
 
     /**
      * Open a channel to a remote service on this connection.

--- a/src/main/java/org/jboss/remoting3/ConnectionImpl.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionImpl.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.security.Principal;
 import java.util.Collection;
 
+import javax.net.ssl.SSLSession;
+
 import org.jboss.remoting3.security.UserInfo;
 import org.jboss.remoting3.spi.AbstractHandleableCloseable;
 import org.jboss.remoting3.spi.ConnectionHandler;
@@ -68,6 +70,11 @@ class ConnectionImpl extends AbstractHandleableCloseable<Connection> implements 
     @Override
     public UserInfo getUserInfo() {
         return connectionHandler.getUserInfo();
+    }
+
+    @Override
+    public SSLSession getSslSession() {
+        return connectionHandler.getSslSession();
     }
 
     public IoFuture<Channel> openChannel(final String serviceType, final OptionMap optionMap) {

--- a/src/main/java/org/jboss/remoting3/LocalConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/LocalConnectionProvider.java
@@ -41,6 +41,7 @@ import org.xnio.OptionMap;
 import org.xnio.Result;
 import org.xnio.ssl.XnioSsl;
 
+import javax.net.ssl.SSLSession;
 import javax.security.auth.callback.CallbackHandler;
 
 import static org.xnio.IoUtils.nullCancellable;
@@ -106,6 +107,10 @@ final class LocalConnectionProvider extends AbstractHandleableCloseable<Connecti
                 }
 
             };
+        }
+
+        public SSLSession getSslSession() {
+            return null;
         }
 
         public String getRemoteEndpointName() {

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import javax.net.ssl.SSLSession;
+
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.NotOpenException;
 import org.jboss.remoting3.ProtocolException;
@@ -47,6 +49,7 @@ import org.xnio.OptionMap;
 import org.xnio.Pooled;
 import org.xnio.Result;
 import org.xnio.channels.ConnectedMessageChannel;
+import org.xnio.channels.SslChannel;
 
 final class RemoteConnectionHandler extends AbstractHandleableCloseable<ConnectionHandler> implements ConnectionHandler {
 
@@ -368,6 +371,11 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
 
     public UserInfo getUserInfo() {
         return userInfo;
+    }
+
+    public SSLSession getSslSession() {
+        SslChannel sslChannel = remoteConnection.getSslChannel();
+        return sslChannel != null ? sslChannel.getSslSession() : null;
     }
 
     public String getRemoteEndpointName() {

--- a/src/main/java/org/jboss/remoting3/spi/ConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/spi/ConnectionHandler.java
@@ -24,6 +24,9 @@ package org.jboss.remoting3.spi;
 
 import java.security.Principal;
 import java.util.Collection;
+
+import javax.net.ssl.SSLSession;
+
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.HandleableCloseable;
 import org.jboss.remoting3.security.UserInfo;
@@ -59,6 +62,13 @@ public interface ConnectionHandler extends HandleableCloseable<ConnectionHandler
      * @return the authenticated UserInfo
      */
     UserInfo getUserInfo();
+
+    /**
+     * Get the underlying {@link SSLSession} for this connection if one is established.
+     *
+     * @return the {@link SSLSession} for the connection if one is established, otherwise returns {@code null}.
+     */
+    SSLSession getSslSession();
 
     /**
      * Get the name of the remote endpoint.

--- a/src/test/java/org/jboss/remoting3/test/RemoteChannelTest.java
+++ b/src/test/java/org/jboss/remoting3/test/RemoteChannelTest.java
@@ -23,6 +23,7 @@
 package org.jboss.remoting3.test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.xnio.IoUtils.safeClose;
@@ -50,7 +51,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xnio.FutureResult;
 import org.xnio.IoFuture;
-import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Sequence;
@@ -59,7 +59,7 @@ import org.xnio.channels.ConnectedStreamChannel;
 
 /**
  * Test for remote channel communication.
- * 
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class RemoteChannelTest extends ChannelTestBase {
@@ -92,11 +92,13 @@ public final class RemoteChannelTest extends ChannelTestBase {
         }, OptionMap.EMPTY);
         IoFuture<Connection> futureConnection = endpoint.connect(new URI("remote://localhost:30123"), OptionMap.EMPTY, "bob", "test", "pass".toCharArray());
         connection = futureConnection.get();
+        assertNull("No SSLSession", connection.getSslSession());
         IoFuture<Channel> futureChannel = connection.openChannel("org.jboss.test", OptionMap.EMPTY);
         sendChannel = futureChannel.get();
         recvChannel = passer.getIoFuture().get();
         assertNotNull(recvChannel);
-        assertEquals("bob",recvChannel.getConnection().getUserInfo().getUserName());        
+        assertNull("No SSLSession", recvChannel.getConnection().getSslSession());
+        assertEquals("bob",recvChannel.getConnection().getUserInfo().getUserName());
     }
 
     @After

--- a/src/test/java/org/jboss/remoting3/test/RemoteSslChannelTest.java
+++ b/src/test/java/org/jboss/remoting3/test/RemoteSslChannelTest.java
@@ -91,10 +91,12 @@ public final class RemoteSslChannelTest extends ChannelTestBase {
         }, OptionMap.EMPTY);
         IoFuture<Connection> futureConnection = endpoint.connect(new URI("remote://localhost:30123"), OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE), "bob", "test", "pass".toCharArray());
         connection = futureConnection.get();
+        assertNotNull("SSLSession Available", connection.getSslSession());
         IoFuture<Channel> futureChannel = connection.openChannel("org.jboss.test", OptionMap.EMPTY);
         sendChannel = futureChannel.get();
         recvChannel = passer.getIoFuture().get();
         assertNotNull(recvChannel);
+        assertNotNull("SSLSession Available", recvChannel.getConnection().getSslSession());
     }
 
     @After


### PR DESCRIPTION
...if one is available.

Also a minor update to existing tests to verify that either the SSLSession instance is returned or null is returned as applicable.
