### PR TITLE
[REM3-193] At RemoteReadListener.handleEvent, do not return after receiv...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.jboss.remoting</groupId>
     <artifactId>jboss-remoting</artifactId>
-    <version>4.0.5.Beta1</version>
+    <version>4.0.5.Final-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 


### PR DESCRIPTION
...ing a CONNECTION_CLOSE, instead, try to receive a message one more time to make sure we are not skipping any receive equal to -1

This fix is necessary to upgrade xnio to 3.3.0.Beta2 in wildfly-core.
