### PR TITLE
[WFCORE-112] Long server shut-dow with unresponsive client with opened JNDI Context

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -109,15 +109,11 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
      * The socket channel was closed with or without our consent.
      */
     void handleConnectionClose() {
+        sendCloseRequest();
         closePendingChannels();
         closeAllChannels();
         remoteConnection.shutdownWrites();
         IoUtils.safeShutdownReads(remoteConnection.getChannel());
-        try {
-            closeAction();
-        } catch (IOException ignored) {
-            log.tracef(ignored, "Failure to close after forced connection close");
-        }
         remoteConnection.getRemoteConnectionProvider().removeConnectionHandler(this);
         closeComplete();
     }
@@ -410,7 +406,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     }
 
     protected void closeAction() throws IOException {
-        sendCloseRequest();
+        handleConnectionClose();
     }
 
     private void closePendingChannels() {


### PR DESCRIPTION
This removes the deadlock that is happening due to a network failure during closeAsync call.
The close async was doing this: 
1) send close (endpoint A)
2) receive close (endpoint B)
3) send close (endpoint B) 
4) receive close (endpoint A) -> close the channel
If the network fails point 2 never takes place, then endpoint A waits
forever. It is changed to:
1) send close (endpoint A) -> close the channel
2) receive close (endpoint B) -> close the channel
