### PR TITLE
[REM3-202] Ensure locale for test is English

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,10 @@
                             <name>jboss.remoting.debug-buffer-leaks</name>
                             <value>${leak.debug}</value>
                         </property>
+                        <systemPropertyVariables>
+                            <user.language>en</user.language>
+                            <user.region>US</user.region>
+                        </systemPropertyVariables>
                     </systemProperties>
                     <enableAssertions>true</enableAssertions>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>


### PR DESCRIPTION
Configure unit test to run with English as a locale - not as nice as having "non local bound" unit test, but at least build works out of the boxe now, even if you happen to run non-english system.
