### PR TITLE
[BZ-1262449]  Revert prior changes that introduce OutboundMessage.cancel deadlock

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/IntIndexHashMap.java
+++ b/src/main/java/org/jboss/remoting3/remote/IntIndexHashMap.java
@@ -200,14 +200,18 @@ final class IntIndexHashMap<V> extends AbstractCollection<V> implements IntIndex
     }
 
     public <T> T[] toArray(final T[] a) {
-        final ArrayList<T> list = new ArrayList<T>(size());
-        list.addAll((Collection<T>) this);
+        final ArrayList<V> list = new ArrayList<V>(size());
+        for (V item : this) {
+            list.add(item);
+        }
         return list.toArray(a);
     }
 
     public Object[] toArray() {
         final ArrayList<Object> list = new ArrayList<Object>(size());
-        list.addAll(this);
+        for (V item : this) {
+            list.add(item);
+        }
         return list.toArray();
     }
 

--- a/src/main/java/org/jboss/remoting3/remote/IntIndexHashMap.java
+++ b/src/main/java/org/jboss/remoting3/remote/IntIndexHashMap.java
@@ -200,18 +200,14 @@ final class IntIndexHashMap<V> extends AbstractCollection<V> implements IntIndex
     }
 
     public <T> T[] toArray(final T[] a) {
-        final ArrayList<V> list = new ArrayList<V>(size());
-        for (V item : this) {
-            list.add(item);
-        }
+        final ArrayList<T> list = new ArrayList<T>(size());
+        list.addAll((Collection<T>) this);
         return list.toArray(a);
     }
 
     public Object[] toArray() {
         final ArrayList<Object> list = new ArrayList<Object>(size());
-        for (V item : this) {
-            list.add(item);
-        }
+        list.addAll(this);
         return list.toArray();
     }
 

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
@@ -59,7 +59,6 @@ final class RemoteConnection {
     private final int heartbeatInterval;
     private volatile Result<ConnectionHandlerFactory> result;
     private volatile SaslWrapper saslWrapper;
-    private volatile boolean closing;
     private final RemoteConnectionProvider remoteConnectionProvider;
 
     RemoteConnection(final Pool<ByteBuffer> messageBufferPool, final ConnectedStreamChannel underlyingChannel, final ConnectedMessageChannel channel, final OptionMap optionMap, final RemoteConnectionProvider remoteConnectionProvider) {
@@ -212,10 +211,6 @@ final class RemoteConnection {
         return writeListener.queue;
     }
 
-    void closing() {
-        this.closing = true;
-    }
-
     final class RemoteWriteListener implements ChannelListener<ConnectedMessageChannel> {
 
         private final Queue<Pooled<ByteBuffer>> queue = new ArrayDeque<Pooled<ByteBuffer>>();
@@ -226,7 +221,7 @@ final class RemoteConnection {
         }
 
         public void handleEvent(final ConnectedMessageChannel channel) {
-            synchronized (getLock()) {
+            synchronized (queue) {
                 assert channel == getChannel();
                 Pooled<ByteBuffer> pooled;
                 final Queue<Pooled<ByteBuffer>> queue = this.queue;
@@ -269,7 +264,7 @@ final class RemoteConnection {
         }
 
         public void shutdownWrites() {
-            synchronized (getLock()) {
+            synchronized (queue) {
                 closed = true;
                 terminateHeartbeat();
                 final ConnectedMessageChannel channel = getChannel();
@@ -296,61 +291,59 @@ final class RemoteConnection {
         }
 
         public void send(Pooled<ByteBuffer> pooled, final boolean close) {
-            if(!closing) {
-                synchronized (getLock()) {
-                    XnioExecutor.Key heartKey = this.heartKey;
-                    if (heartKey != null) heartKey.remove();
-                    if (closed) { pooled.free(); return; }
-                    if (close) { closed = true; }
-                    final ConnectedMessageChannel channel = getChannel();
-                    boolean free = true;
-                    try {
-                        final SaslWrapper wrapper = saslWrapper;
-                        if (wrapper != null) {
-                            final ByteBuffer buffer = pooled.getResource();
-                            final ByteBuffer source = buffer.duplicate();
-                            buffer.clear();
-                            wrapper.wrap(buffer, source);
-                            buffer.flip();
-                        }
-                        if (queue.isEmpty()) {
-                            final ByteBuffer buffer = pooled.getResource();
-                            if (! channel.send(buffer)) {
-                                RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Can't directly send message %s, enqueued", buffer);
-                                queue.add(pooled);
-                                free = false;
-                                channel.resumeWrites();
-                                return;
-                            }
-                            RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Sent message %s (direct)", buffer);
-                            if (close) {
-                                channel.shutdownWrites();
-                                RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Shut down writes on channel (direct)");
-                                // fall thru to flush
-                            }
-                            if (! channel.flush()) {
-                                channel.resumeWrites();
-                                return;
-                            }
-                            RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Flushed channel (direct)");
-                            if (! close) {
-                                this.heartKey = channel.getWriteThread().executeAfter(heartbeatCommand, heartbeatInterval, TimeUnit.MILLISECONDS);
-                            }
-                        } else {
+            synchronized (queue) {
+                XnioExecutor.Key heartKey = this.heartKey;
+                if (heartKey != null) heartKey.remove();
+                if (closed) { pooled.free(); return; }
+                if (close) { closed = true; }
+                final ConnectedMessageChannel channel = getChannel();
+                boolean free = true;
+                try {
+                    final SaslWrapper wrapper = saslWrapper;
+                    if (wrapper != null) {
+                        final ByteBuffer buffer = pooled.getResource();
+                        final ByteBuffer source = buffer.duplicate();
+                        buffer.clear();
+                        wrapper.wrap(buffer, source);
+                        buffer.flip();
+                    }
+                    if (queue.isEmpty()) {
+                        final ByteBuffer buffer = pooled.getResource();
+                        if (! channel.send(buffer)) {
+                            RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Can't directly send message %s, enqueued", buffer);
                             queue.add(pooled);
                             free = false;
+                            channel.resumeWrites();
+                            return;
                         }
-                    } catch (IOException e) {
-                        handleException(e, false);
-                        channel.wakeupReads();
-                        Pooled<ByteBuffer> unqueued;
-                        while ((unqueued = queue.poll()) != null) {
-                            unqueued.free();
+                        RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Sent message %s (direct)", buffer);
+                        if (close) {
+                            channel.shutdownWrites();
+                            RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Shut down writes on channel (direct)");
+                            // fall thru to flush
                         }
-                    } finally {
-                        if (free) {
-                            pooled.free();
+                        if (! channel.flush()) {
+                            channel.resumeWrites();
+                            return;
                         }
+                        RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Flushed channel (direct)");
+                        if (! close) {
+                            this.heartKey = channel.getWriteThread().executeAfter(heartbeatCommand, heartbeatInterval, TimeUnit.MILLISECONDS);
+                        }
+                    } else {
+                        queue.add(pooled);
+                        free = false;
+                    }
+                } catch (IOException e) {
+                    handleException(e, false);
+                    channel.wakeupReads();
+                    Pooled<ByteBuffer> unqueued;
+                    while ((unqueued = queue.poll()) != null) {
+                        unqueued.free();
+                    }
+                } finally {
+                    if (free) {
+                        pooled.free();
                     }
                 }
             }

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionChannel.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionChannel.java
@@ -23,19 +23,15 @@
 package org.jboss.remoting3.remote;
 
 import static org.jboss.remoting3.remote.RemoteLogger.log;
-import static org.xnio.IoUtils.safeClose;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Queue;
 import java.util.Random;
 
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.jboss.remoting3.Attachments;
 import org.jboss.remoting3.Channel;
@@ -361,18 +357,14 @@ final class RemoteConnectionChannel extends AbstractHandleableCloseable<Channel>
     }
 
     public void receiveMessage(final Receiver handler) {
-        boolean immediateEnd = false;
         synchronized (connection.getLock()) {
             if (inboundMessageQueue.isEmpty()) {
-                if ((channelState & READ_CLOSED) != 0) try {
+                if ((channelState & READ_CLOSED) != 0) {
                     getExecutor().execute(new Runnable() {
                         public void run() {
                             handler.handleEnd(RemoteConnectionChannel.this);
                         }
                     });
-                } catch (RejectedExecutionException ignored) {
-                    // oops, endpoint shut down out from under us; call directly and hope for the best
-                    immediateEnd = true;
                 } else if (nextReceiver != null) {
                     throw new IllegalStateException("Message handler already queued");
                 } else {
@@ -386,16 +378,12 @@ final class RemoteConnectionChannel extends AbstractHandleableCloseable<Channel>
                             handler.handleMessage(RemoteConnectionChannel.this, message.messageInputStream);
                         }
                     });
-                } catch (RejectedExecutionException ignored) {
-                    safeClose(message.messageInputStream);
-                    // oops, endpoint shut down out from under us; call handleEnd directly and hope for the best
-                    immediateEnd = true;
+                } catch (Throwable t) {
+                    connection.handleException(new IOException("Fatal connection error", t));
+                    return;
                 }
             }
             connection.getLock().notify();
-        }
-        if (immediateEnd) {
-            handler.handleEnd(this);
         }
     }
 
@@ -544,23 +532,30 @@ final class RemoteConnectionChannel extends AbstractHandleableCloseable<Channel>
     }
 
     private void closeMessages() {
-        final List<InboundMessage> exceptionMessages;
-        final List<OutboundMessage> cancelMessages;
-        final List<InboundMessage> terminateMessages;
+        Executor executor = connection.getExecutor();
         synchronized (connection.getLock()) {
-            exceptionMessages = new ArrayList<InboundMessage>(inboundMessages);
-            cancelMessages = new ArrayList<OutboundMessage>(outboundMessages);
-            terminateMessages = new ArrayList<InboundMessage>(inboundMessageQueue);
+            for (final InboundMessage message : inboundMessages) {
+                executor.execute(new Runnable() {
+                    public void run() {
+                        message.inputStream.pushException(new MessageCancelledException());
+                    }
+                });
+            }
+            for (final OutboundMessage message : outboundMessages) {
+                executor.execute(new Runnable() {
+                    public void run() {
+                        message.cancel();
+                    }
+                });
+            }
+            for (final InboundMessage message : inboundMessageQueue) {
+                executor.execute(new Runnable() {
+                    public void run() {
+                        message.terminate();
+                    }
+                });
+            }
             inboundMessageQueue.clear();
-        }
-        for (final InboundMessage message : exceptionMessages) {
-            message.inputStream.pushException(new MessageCancelledException());
-        }
-        for (final OutboundMessage message : cancelMessages) {
-            message.cancel();
-        }
-        for (final InboundMessage message : terminateMessages) {
-            message.terminate();
         }
     }
 

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -106,28 +106,19 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
         this.userInfo = userInfo;
     }
 
- void handleConnectionClose() {
+    /**
+     * The socket channel was closed with or without our consent.
+     */
+    void handleConnectionClose() {
         sendCloseRequest();
         closePendingChannels();
         closeAllChannels();
         remoteConnection.shutdownWrites();
         IoUtils.safeShutdownReads(remoteConnection.getChannel());
         remoteConnection.getRemoteConnectionProvider().removeConnectionHandler(this);
-        IoUtils.safeClose(remoteConnection.getChannel());
+        closeComplete();
     }
 
-    /**
-     * The socket channel was closed with or without our consent.
-     */
-    void handleSocketChannelClose() {
-        remoteConnection.getExecutor().execute(new Runnable() {
-            public void run() {
-                handleConnectionClose();
-                closeComplete();
-            }
-        });
-    }
-    
     /**
      * A channel was closed, locally or remotely.
      *

--- a/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
@@ -73,7 +73,6 @@ final class RemoteReadListener implements ChannelListener<ConnectedMessageChanne
                             log.trace("Received connection end-of-stream");
                             try {
                                 channel.shutdownReads();
-                                connection.closing();
                             } finally {
                                 handler.handleConnectionClose();
                             }

--- a/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
@@ -51,7 +51,11 @@ final class RemoteReadListener implements ChannelListener<ConnectedMessageChanne
         synchronized (connection.getLock()) {
             connection.getChannel().getCloseSetter().set(new ChannelListener<java.nio.channels.Channel>() {
                 public void handleEvent(final java.nio.channels.Channel channel) {
-                    handler.handleSocketChannelClose();
+                    connection.getExecutor().execute(new Runnable() {
+                        public void run() {
+                            handler.handleConnectionClose();
+                        }
+                    });
                 }
             });
         }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1262114

Prior executor removal changes introduced the BZ-1262449 deadlock so reverting these involved changes.

https://github.com/jboss-remoting/jboss-remoting/commit/97bddc0d16deb421f1dea0baa61aeaeaa7c504b4

https://github.com/jboss-remoting/jboss-remoting/commit/055f0c4b133a3cb361d8d7c9ba7825e000ee1386

https://github.com/jboss-remoting/jboss-remoting/commit/eff6cb787f567d2a917844c189bb4fa565e0257b