### PR TITLE
[BZ-1280507] Endpoint can be closed before doConnect tasks finished causing AbstractHandleableCloseable.close to wait forever

### DIFF
--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -51,10 +51,12 @@ import org.jboss.remoting3.spi.ConnectionProviderContext;
 import org.jboss.remoting3.spi.ConnectionProviderFactory;
 import org.jboss.remoting3.spi.RegisteredService;
 import org.jboss.remoting3.spi.SpiUtils;
+import org.xnio.Bits;
 import org.xnio.Cancellable;
 import org.xnio.FutureResult;
 import org.xnio.IoFuture;
 import org.xnio.IoFuture.HandlingNotifier;
+import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Xnio;
@@ -189,6 +191,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
         }
     }
 
+
     void executorUntick(Object opened) {
         // just like resourceUntick - except we allow tasks to be submitted after close begins.
         int old;
@@ -201,6 +204,10 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
         if (log.isTraceEnabled()) {
             log.tracef("Allocated tick to %d of %s (opened %s)", Integer.valueOf(old + 1), this, opened);
         }
+    }
+
+    boolean isCloseFlagSet() {
+        return Bits.allAreSet(resourceCountUpdater.get(this), CLOSED_FLAG);
     }
 
     protected void closeAction() throws IOException {
@@ -300,13 +307,27 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
                     }
 
                     public void handleDone(final ConnectionHandlerFactory connHandlerFactory, final Void attachment) {
-                        log.logf(getClass().getName(), Logger.Level.TRACE, null, "Registered successful result %s", connHandlerFactory);
-                        final ConnectionImpl connection = new ConnectionImpl(EndpointImpl.this, connHandlerFactory, connectionProviderContext);
-                        connections.add(connection);
-                        connection.getConnectionHandler().addCloseHandler(SpiUtils.asyncClosingCloseHandler(connection));
-                        connection.addCloseHandler(resourceCloseHandler);
-                        connection.addCloseHandler(connectionCloseHandler);
-                        futureResult.setResult(connection);
+                        worker.execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                log.logf(getClass().getName(), Logger.Level.TRACE, null, "Registered successful result %s", connHandlerFactory);
+                                synchronized (EndpointImpl.this.connectionLock) {
+                                    final ConnectionImpl connection = new ConnectionImpl(EndpointImpl.this, connHandlerFactory, connectionProviderContext);
+                                    connection.getConnectionHandler().addCloseHandler(SpiUtils.asyncClosingCloseHandler(connection));
+                                    connection.addCloseHandler(resourceCloseHandler);
+                                    connection.addCloseHandler(connectionCloseHandler);
+                                    // see if we were closed in the meantime
+                                    if (EndpointImpl.this.isCloseFlagSet()) {
+                                        IoUtils.safeClose(connection);
+                                        futureResult.setCancelled();
+                                    } else {
+                                        connections.add(connection);
+                                        futureResult.setResult(connection);
+                                    }                            
+                                } 
+                            }
+                        });
+
                     }
                 }, null);
                 final Cancellable connect = connectionProvider.connect(bindAddress, destination, connectOptions,  connHandlerFuture, callbackHandler, xnioSsl);


### PR DESCRIPTION
Jira 7.0.0: https://issues.jboss.org/browse/JBEAP-2017
BZ 6.4.z https://bugzilla.redhat.com/show_bug.cgi?id=1280507

PR upstream 7.0.0: https://github.com/jboss-remoting/jboss-remoting/pull/56

detect during authentication if the endpoint is closed.
if that's the case discards the connection.