### PR TITLE
[REM3-214] RemoteKerberosChannelTest fails with IBM jdk 1.8 on login

### DIFF
--- a/src/test/resources/krb5.conf
+++ b/src/test/resources/krb5.conf
@@ -1,7 +1,7 @@
 [libdefaults]
 	default_realm = JBOSS.ORG
-	default_tgs_enctypes = des-cbc-md5,des3-cbc-sha1-kd
-	default_tkt_enctypes = des-cbc-md5,des3-cbc-sha1-kd
+	default_tgs_enctypes = aes128-cts-hmac-sha1-96,des-cbc-md5,des3-cbc-sha1-kd
+	default_tkt_enctypes = aes128-cts-hmac-sha1-96,des-cbc-md5,des3-cbc-sha1-kd
 	kdc_timeout = 5000
 	dns_lookup_realm = false
 	dns_lookup_kdc = false


### PR DESCRIPTION
https://issues.jboss.org/browse/REM3-214