### PR TITLE
[REM3-215] org.jboss.remoting3.test.OutboundMessageCountTestCase

### DIFF
--- a/src/test/java/org/jboss/remoting3/test/OutboundMessageCountTestCase.java
+++ b/src/test/java/org/jboss/remoting3/test/OutboundMessageCountTestCase.java
@@ -50,6 +50,7 @@ import org.jboss.remoting3.OpenListener;
 import org.jboss.remoting3.Registration;
 import org.jboss.remoting3.RemotingOptions;
 import org.jboss.remoting3.spi.NetworkServerProvider;
+import org.jboss.remoting3.test.util.InetAddressUtil;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -124,7 +125,7 @@ public class OutboundMessageCountTestCase {
         builder.setFactory(saslServerFactory);
         builder.addMechanism(SaslMechanismInformation.Names.SCRAM_SHA_256, MechanismConfiguration.EMPTY);
         final SaslAuthenticationFactory saslAuthenticationFactory = builder.build();
-        streamServer = networkServerProvider.createServer(new InetSocketAddress("::1", 30123), OptionMap.EMPTY, saslAuthenticationFactory);
+        streamServer = networkServerProvider.createServer(InetAddressUtil.getLocalInetSocketAddress(), OptionMap.EMPTY, saslAuthenticationFactory);
     }
 
     @Before
@@ -144,7 +145,7 @@ public class OutboundMessageCountTestCase {
         IoFuture<Connection> futureConnection = AuthenticationContext.empty().with(MatchRule.ALL, AuthenticationConfiguration.EMPTY.useName("bob").usePassword("pass").allowSaslMechanisms("SCRAM-SHA-256")).run(new PrivilegedAction<IoFuture<Connection>>() {
             public IoFuture<Connection> run() {
                 try {
-                    return endpoint.connect(new URI("remote://[::1]:30123"), OptionMap.EMPTY);
+                    return endpoint.connect(InetAddressUtil.getLocalURI(), OptionMap.EMPTY);
                 } catch (IOException | URISyntaxException e) {
                     throw new RuntimeException(e);
                 }

--- a/src/test/java/org/jboss/remoting3/test/util/InetAddressUtil.java
+++ b/src/test/java/org/jboss/remoting3/test/util/InetAddressUtil.java
@@ -1,0 +1,56 @@
+package org.jboss.remoting3.test.util;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.jboss.logging.Logger;
+
+public final class InetAddressUtil {
+
+    private static final Logger logger = Logger.getLogger(InetAddressUtil.class);
+
+    private static final int LOCAL_PORT = 30123;
+    private static final String LOCAL_IPv4_ADDRESS = "127.0.0.1";
+    private static final String LOCAL_IPv6_ADDRESS = "[::1]";
+
+    private static boolean IPv4Supported;
+
+    private static boolean IPv6Supported;
+
+    private InetAddressUtil () {}
+
+    static {
+        IPv4Supported = check(LOCAL_IPv4_ADDRESS, LOCAL_PORT);
+        IPv6Supported = check(LOCAL_IPv6_ADDRESS, LOCAL_PORT);
+    }
+
+    public static boolean check(String ip, int port) {
+        try(Socket socket = new Socket()) {
+            socket.bind(new InetSocketAddress(ip, port));
+            return true;
+        } catch (IOException e) {
+            logger.errorf(e, "address not supported %s:%d", ip, port);
+            return false;
+        }
+    }
+
+    public static boolean isIPv4supported() {
+        return IPv4Supported;
+    }
+
+    public static boolean isIPv6supported() {
+        return IPv6Supported;
+    }
+
+    public static InetSocketAddress getLocalInetSocketAddress() {
+        return new InetSocketAddress((IPv6Supported) ? LOCAL_IPv6_ADDRESS : LOCAL_IPv4_ADDRESS, LOCAL_PORT);
+    }
+
+    public static URI getLocalURI() throws URISyntaxException {
+        return new URI("remote", null, (IPv6Supported) ? LOCAL_IPv6_ADDRESS : LOCAL_IPv4_ADDRESS, LOCAL_PORT, null, null, null);
+    }
+
+}


### PR DESCRIPTION
added logic for avoiding failure in systems where IPv6 is not supported.

This can be tested disabling ipv6. In Linux system can be achieved with the next command

sudo sh -c 'echo 1 > /proc/sys/net/ipv6/conf/lo/disable_ipv6'
