### PR TITLE
[REM3-245] The Elytron AuthenticationConfiguration now manages the SaslClientFactory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <apacheds.jdbm1.version>2.0.0-M2</apacheds.jdbm1.version>
         <apacheds.shared.version>1.0.0-M13</apacheds.shared.version>
         <apacheds.api.version>1.0.0-M16</apacheds.api.version>        
-        <elytron.version>1.1.0.Beta14</elytron.version>
+        <elytron.version>1.1.0.Beta15</elytron.version>
         <config.version>1.0.0.Alpha3</config.version>
         <xnio.version>3.4.0.Beta3</xnio.version>
         <logging.version>3.2.1.Final</logging.version>

--- a/src/main/java/org/jboss/remoting3/ConnectionBuilder.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionBuilder.java
@@ -25,6 +25,7 @@ package org.jboss.remoting3;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import javax.security.sasl.SaslClientFactory;
 
@@ -43,7 +44,7 @@ public final class ConnectionBuilder {
 
     private final URI uri;
     private boolean immediate;
-    private SaslClientFactory saslClientFactory;
+    private UnaryOperator<SaslClientFactory> saslClientFactoryOperator = UnaryOperator.identity();
     private AuthenticationContext authenticationContext;
     private SocketAddress bindAddress;
     private String abstractType;
@@ -59,9 +60,9 @@ public final class ConnectionBuilder {
         return this;
     }
 
-    public ConnectionBuilder setSaslClientFactory(final SaslClientFactory saslClientFactory) {
-        Assert.checkNotNullParam("saslClientFactory", saslClientFactory);
-        this.saslClientFactory = saslClientFactory;
+    public ConnectionBuilder setSaslClientFactoryOperator(final UnaryOperator<SaslClientFactory> saslClientFactoryOperator) {
+        Assert.checkNotNullParam("saslClientFactoryOperator", saslClientFactoryOperator);
+        this.saslClientFactoryOperator = saslClientFactoryOperator;
         return this;
     }
 
@@ -148,8 +149,8 @@ public final class ConnectionBuilder {
         return immediate;
     }
 
-    SaslClientFactory getSaslClientFactory() {
-        return saslClientFactory;
+    UnaryOperator<SaslClientFactory> getSaslClientFactoryOperator() {
+        return saslClientFactoryOperator;
     }
 
     AuthenticationContext getAuthenticationContext() {

--- a/src/main/java/org/jboss/remoting3/ConnectionImpl.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionImpl.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.security.Principal;
+import java.util.function.UnaryOperator;
 
 import javax.net.ssl.SSLSession;
 import javax.security.sasl.SaslClientFactory;
@@ -63,7 +64,7 @@ class ConnectionImpl extends AbstractHandleableCloseable<Connection> implements 
     private final SaslAuthenticationFactory authenticationFactory;
     private final AuthenticationConfiguration authenticationConfiguration;
 
-    ConnectionImpl(final EndpointImpl endpoint, final ConnectionHandlerFactory connectionHandlerFactory, final ConnectionProviderContext connectionProviderContext, final URI peerUri, final Principal principal, final SaslClientFactory saslClientFactory, final SaslAuthenticationFactory authenticationFactory, final AuthenticationConfiguration authenticationConfiguration) {
+    ConnectionImpl(final EndpointImpl endpoint, final ConnectionHandlerFactory connectionHandlerFactory, final ConnectionProviderContext connectionProviderContext, final URI peerUri, final Principal principal, final UnaryOperator<SaslClientFactory> saslClientFactoryOperator, final SaslAuthenticationFactory authenticationFactory, final AuthenticationConfiguration authenticationConfiguration) {
         super(endpoint.getExecutor(), true);
         this.endpoint = endpoint;
         this.peerUri = peerUri;
@@ -71,7 +72,7 @@ class ConnectionImpl extends AbstractHandleableCloseable<Connection> implements 
         this.authenticationConfiguration = authenticationConfiguration;
         this.connectionHandler = connectionHandlerFactory.createInstance(endpoint.new LocalConnectionContext(connectionProviderContext, this));
         this.authenticationFactory = authenticationFactory;
-        this.peerIdentityContext = new ConnectionPeerIdentityContext(this, saslClientFactory, authenticationFactory == null ? null : authenticationFactory.getMechanismNames());
+        this.peerIdentityContext = new ConnectionPeerIdentityContext(this, authenticationFactory == null ? null : authenticationFactory.getMechanismNames());
     }
 
     protected void closeAction() throws IOException {

--- a/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
@@ -57,7 +57,6 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
 
     private static final byte[] NO_BYTES = new byte[0];
     private final ConnectionImpl connection;
-    private final SaslClientFactory factory;
     private final Collection<String> offeredMechanisms;
     private final ConnectionPeerIdentity anonymousIdentity;
     private final ConnectionPeerIdentity connectionIdentity;
@@ -65,9 +64,8 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
 
     private static final AuthenticationContextConfigurationClient CLIENT = doPrivileged((PrivilegedAction<AuthenticationContextConfigurationClient>) AuthenticationContextConfigurationClient::new);
 
-    ConnectionPeerIdentityContext(final ConnectionImpl connection, final SaslClientFactory factory, final Collection<String> offeredMechanisms) {
+    ConnectionPeerIdentityContext(final ConnectionImpl connection, final Collection<String> offeredMechanisms) {
         this.connection = connection;
-        this.factory = factory;
         this.offeredMechanisms = offeredMechanisms;
         anonymousIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, AnonymousPrincipal.getInstance(), 0, connection));
         connectionIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, connection.getPrincipal(), 1, connection));
@@ -110,7 +108,7 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
             Set<String> mechanisms = new LinkedHashSet<>(offeredMechanisms);
             while (! mechanisms.isEmpty()) {
                 try {
-                    saslClient = client.createSaslClient(connection.getPeerURI(), configuration, factory, mechanisms);
+                    saslClient = client.createSaslClient(connection.getPeerURI(), configuration, mechanisms);
                 } catch (SaslException e) {
                     throw log.authenticationNoSaslClient(e);
                 }

--- a/src/main/java/org/jboss/remoting3/Endpoint.java
+++ b/src/main/java/org/jboss/remoting3/Endpoint.java
@@ -155,22 +155,6 @@ public interface Endpoint extends HandleableCloseable<Endpoint>, Attachable, Con
      *
      * @param destination the destination
      * @param connectOptions options to configure this connection
-     * @param saslClientFactory the SASL client factory to use for client authentication
-     *
-     * @return the future connection
-     *
-     * @throws IOException if an error occurs while starting the connect attempt
-     */
-    IoFuture<Connection> connect(URI destination, OptionMap connectOptions, SaslClientFactory saslClientFactory) throws IOException;
-
-    /**
-     * Open a connection with a peer.  Returns a future connection which may be used to cancel the connection attempt.
-     * This method does not block; use the return value to wait for a result if you wish to block.
-     * <p/>
-     * You must have the {@link RemotingPermission connect EndpointPermission} to invoke this method.
-     *
-     * @param destination the destination
-     * @param connectOptions options to configure this connection
      * @param authenticationContext the client authentication context to use
      *
      * @return the future connection
@@ -178,23 +162,6 @@ public interface Endpoint extends HandleableCloseable<Endpoint>, Attachable, Con
      * @throws IOException if an error occurs while starting the connect attempt
      */
     IoFuture<Connection> connect(URI destination, OptionMap connectOptions, AuthenticationContext authenticationContext) throws IOException;
-
-    /**
-     * Open a connection with a peer.  Returns a future connection which may be used to cancel the connection attempt.
-     * This method does not block; use the return value to wait for a result if you wish to block.
-     * <p/>
-     * You must have the {@link RemotingPermission connect EndpointPermission} to invoke this method.
-     *
-     * @param destination the destination
-     * @param connectOptions options to configure this connection
-     * @param authenticationContext the client authentication context to use
-     * @param saslClientFactory the SASL client factory to use for client authentication
-     *
-     * @return the future connection
-     *
-     * @throws IOException if an error occurs while starting the connect attempt
-     */
-    IoFuture<Connection> connect(URI destination, OptionMap connectOptions, AuthenticationContext authenticationContext, SaslClientFactory saslClientFactory) throws IOException;
 
     /**
      * Open a connection with a peer.  Returns a future connection which may be used to cancel the connection attempt.
@@ -212,7 +179,7 @@ public interface Endpoint extends HandleableCloseable<Endpoint>, Attachable, Con
      *
      * @throws IOException if an error occurs while starting the connect attempt
      */
-    IoFuture<Connection> connect(URI destination, InetSocketAddress bindAddress, OptionMap connectOptions, AuthenticationContext authenticationContext, SaslClientFactory saslClientFactory) throws IOException;
+    IoFuture<Connection> connect(URI destination, InetSocketAddress bindAddress, OptionMap connectOptions, AuthenticationContext authenticationContext) throws IOException;
 
     /**
      * Register a connection provider for a URI scheme.  The provider factory is called with the context which can

--- a/src/main/java/org/jboss/remoting3/RemotingXmlParser.java
+++ b/src/main/java/org/jboss/remoting3/RemotingXmlParser.java
@@ -298,7 +298,6 @@ final class RemotingXmlParser {
         }
         final ConnectionBuilder connectionBuilder = builder.addConnection(uri);
         connectionBuilder.setImmediate(immediate);
-        connectionBuilder.setSaslClientFactory(SaslFactories.getElytronSaslClientFactory());
         connectionBuilder.setAuthenticationContext(getGlobalDefaultAuthCtxt());
         while (reader.hasNext()) {
             switch (reader.nextTag()) {

--- a/src/main/java/org/jboss/remoting3/UncloseableEndpoint.java
+++ b/src/main/java/org/jboss/remoting3/UncloseableEndpoint.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 
-import javax.security.sasl.SaslClientFactory;
-
 import org.jboss.remoting3.spi.ConnectionProviderFactory;
 import org.wildfly.common.Assert;
 import org.wildfly.common.context.ContextManager;
@@ -63,20 +61,13 @@ final class UncloseableEndpoint implements Endpoint {
         return endpoint.connect(destination, connectOptions);
     }
 
-    public IoFuture<Connection> connect(final URI destination, final OptionMap connectOptions, final SaslClientFactory saslClientFactory) throws IOException {
-        return endpoint.connect(destination, connectOptions, saslClientFactory);
-    }
 
     public IoFuture<Connection> connect(final URI destination, final OptionMap connectOptions, final AuthenticationContext authenticationContext) throws IOException {
         return endpoint.connect(destination, connectOptions, authenticationContext);
     }
 
-    public IoFuture<Connection> connect(final URI destination, final OptionMap connectOptions, final AuthenticationContext authenticationContext, final SaslClientFactory saslClientFactory) throws IOException {
-        return endpoint.connect(destination, connectOptions, authenticationContext, saslClientFactory);
-    }
-
-    public IoFuture<Connection> connect(final URI destination, final InetSocketAddress bindAddress, final OptionMap connectOptions, final AuthenticationContext authenticationContext, final SaslClientFactory saslClientFactory) throws IOException {
-        return endpoint.connect(destination, bindAddress, connectOptions, authenticationContext, saslClientFactory);
+    public IoFuture<Connection> connect(URI destination, InetSocketAddress bindAddress, OptionMap connectOptions, AuthenticationContext authenticationContext) throws IOException {
+        return endpoint.connect(destination, bindAddress, connectOptions, authenticationContext);
     }
 
     public Registration addConnectionProvider(final String uriScheme, final ConnectionProviderFactory providerFactory, final OptionMap optionMap) throws DuplicateRegistrationException, IOException {

--- a/src/main/java/org/jboss/remoting3/spi/ConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/spi/ConnectionProvider.java
@@ -25,6 +25,7 @@ package org.jboss.remoting3.spi;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.Collection;
+import java.util.function.UnaryOperator;
 
 import org.jboss.remoting3.HandleableCloseable;
 import org.wildfly.security.SecurityFactory;
@@ -52,12 +53,12 @@ public interface ConnectionProvider extends HandleableCloseable<ConnectionProvid
      * @param result the result which should receive the connection
      * @param authenticationConfiguration the configuration to use for authentication of the connection
      * @param sslContextFactory the SSL context factory to use
-     * @param saslClientFactory the SASL client factory to use for authentication mechanisms
+     * @param saslClientFactoryOperator A unary operator to apply to the SaslClientFactory used.
      * @param serverMechs the list of server mechanism names to advertise to the peer (may be empty; not {@code null})
      * @return a handle which may be used to cancel the connect attempt
      * @throws IllegalArgumentException if any of the given arguments are not valid for this protocol
      */
-    Cancellable connect(URI destination, SocketAddress bindAddress, OptionMap connectOptions, Result<ConnectionHandlerFactory> result, AuthenticationConfiguration authenticationConfiguration, SecurityFactory<SSLContext> sslContextFactory, SaslClientFactory saslClientFactory, final Collection<String> serverMechs);
+    Cancellable connect(URI destination, SocketAddress bindAddress, OptionMap connectOptions, Result<ConnectionHandlerFactory> result, AuthenticationConfiguration authenticationConfiguration, SecurityFactory<SSLContext> sslContextFactory, UnaryOperator<SaslClientFactory> saslClientFactoryOperator, final Collection<String> serverMechs);
 
     /**
      * Get the user data associated with this connection provider.  This object should implement all of the


### PR DESCRIPTION
This is the Remoting side of the changes for https://github.com/wildfly-security/wildfly-elytron/pull/558

Remoting did have quite a bif of default SASL logic, however Remoting will always use an AuthenticationConfiguration so I think it does make sense to keep default SASL handling within AuthenticationConfiguration.

Also I don't currently allow a SaslClientFactory to be passed into Remoting as really if someone wanted to do that they can configure the AuthenticationConfiguration before calling Remoting anyway.