### PR TITLE
Fix for REM3-250. Close SSLConnection

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
@@ -264,6 +264,8 @@ class RemoteConnectionProvider extends AbstractHandleableCloseable<ConnectionPro
                     return;
                 }
                 final JsseSslConnection sslConnection = new JsseSslConnection(streamConnection, engine);
+                // Required in order for the SSLConnection to be properly closed.
+                streamConnection.getCloseSetter().set(channel -> IoUtils.safeClose(sslConnection));
                 if (sslRequired || ! connectOptions.get(Options.SSL_STARTTLS, false)) try {
                     sslConnection.startHandshake();
                 } catch (IOException e) {


### PR DESCRIPTION
Close SSLConnection when underlying connection is closed.
