### PR TITLE
[REM3-252] Fix the way we determine which SASL mechanisms ConnectionPeerIdentityContext.authenticate() should attempt to use

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionImpl.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionImpl.java
@@ -72,7 +72,7 @@ class ConnectionImpl extends AbstractHandleableCloseable<Connection> implements 
         this.authenticationConfiguration = authenticationConfiguration;
         this.connectionHandler = connectionHandlerFactory.createInstance(endpoint.new LocalConnectionContext(connectionProviderContext, this));
         this.authenticationFactory = authenticationFactory;
-        this.peerIdentityContext = new ConnectionPeerIdentityContext(this, authenticationFactory == null ? null : authenticationFactory.getMechanismNames());
+        this.peerIdentityContext = new ConnectionPeerIdentityContext(this, connectionHandler.getOfferedMechanisms());
     }
 
     protected void closeAction() throws IOException {

--- a/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.security.Principal;
 import java.security.PrivilegedAction;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -65,7 +66,7 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
 
     ConnectionPeerIdentityContext(final ConnectionImpl connection, final Collection<String> offeredMechanisms) {
         this.connection = connection;
-        this.offeredMechanisms = offeredMechanisms;
+        this.offeredMechanisms = offeredMechanisms == null ? Collections.emptySet() : offeredMechanisms;
         anonymousIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, AnonymousPrincipal.getInstance(), 0, connection));
         connectionIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, connection.getPrincipal(), 1, connection));
     }

--- a/src/main/java/org/jboss/remoting3/remote/ClientConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ClientConnectionOpenListener.java
@@ -421,7 +421,7 @@ final class ClientConnectionOpenListener implements ChannelListener<ConduitStrea
                         connection.getMessageReader().suspendReads();
                         final int negotiatedVersion = version;
                         final SaslClient usedSaslClient = saslClient;
-                        final Authentication authentication = new Authentication(usedSaslClient, remoteServerName, remoteEndpointName, behavior, channelsIn, channelsOut, authCap);
+                        final Authentication authentication = new Authentication(usedSaslClient, remoteServerName, remoteEndpointName, behavior, channelsIn, channelsOut, authCap, serverSaslMechs);
                         connection.getExecutor().execute(() -> {
                             final byte[] response;
                             try {
@@ -552,8 +552,9 @@ final class ClientConnectionOpenListener implements ChannelListener<ConduitStrea
         private final int maxInboundChannels;
         private final int maxOutboundChannels;
         private final boolean authCap;
+        private final Set<String> offeredMechanisms;
 
-        Authentication(final SaslClient saslClient, final String serverName, final String endpointName, final int behavior, final int maxInboundChannels, final int maxOutboundChannels, final boolean authCap) {
+        Authentication(final SaslClient saslClient, final String serverName, final String endpointName, final int behavior, final int maxInboundChannels, final int maxOutboundChannels, final boolean authCap, final Set<String> offeredMechanisms) {
             this.saslClient = saslClient;
             this.serverName = serverName;
             this.behavior = behavior;
@@ -561,6 +562,7 @@ final class ClientConnectionOpenListener implements ChannelListener<ConduitStrea
             this.maxInboundChannels = maxInboundChannels;
             this.maxOutboundChannels = maxOutboundChannels;
             this.authCap = authCap;
+            this.offeredMechanisms = offeredMechanisms;
         }
 
         public void handleEvent(final ConduitStreamSourceChannel channel) {
@@ -679,7 +681,7 @@ final class ClientConnectionOpenListener implements ChannelListener<ConduitStrea
                                 final ConnectionHandlerFactory connectionHandlerFactory = connectionContext -> {
 
                                     // this happens immediately.
-                                    final RemoteConnectionHandler connectionHandler = new RemoteConnectionHandler(connectionContext, connection, maxInboundChannels, maxOutboundChannels, remoteEndpointName, behavior, authCap);
+                                    final RemoteConnectionHandler connectionHandler = new RemoteConnectionHandler(connectionContext, connection, maxInboundChannels, maxOutboundChannels, remoteEndpointName, behavior, authCap, offeredMechanisms);
                                     connection.setReadListener(new RemoteReadListener(connectionHandler, connection), false);
                                     connection.getRemoteConnectionProvider().addConnectionHandler(connectionHandler);
                                     return connectionHandler;

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -81,6 +82,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
 
     private final int behavior;
     private final boolean supportsRemoteAuth;
+    private final Set<String> offeredMechanisms;
 
     private volatile int channelState = 0;
 
@@ -95,7 +97,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     private static final int INBOUND_CHANNELS_MASK = ((1 << 30) - 1) & ~OUTBOUND_CHANNELS_MASK;
     private static final int ONE_INBOUND_CHANNEL = (1 << 15);
 
-    RemoteConnectionHandler(final ConnectionHandlerContext connectionContext, final RemoteConnection remoteConnection, final int maxInboundChannels, final int maxOutboundChannels, final String remoteEndpointName, final int behavior, final boolean supportsRemoteAuth) {
+    RemoteConnectionHandler(final ConnectionHandlerContext connectionContext, final RemoteConnection remoteConnection, final int maxInboundChannels, final int maxOutboundChannels, final String remoteEndpointName, final int behavior, final boolean supportsRemoteAuth, final Set<String> offeredMechanisms) {
         super(remoteConnection.getExecutor());
         this.connectionContext = connectionContext;
         this.remoteConnection = remoteConnection;
@@ -104,6 +106,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
         this.remoteEndpointName = remoteEndpointName;
         this.behavior = behavior;
         this.supportsRemoteAuth = supportsRemoteAuth;
+        this.offeredMechanisms = offeredMechanisms;
     }
 
     /**
@@ -566,6 +569,10 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
 
     public boolean supportsRemoteAuth() {
         return supportsRemoteAuth;
+    }
+
+    public Set<String> getOfferedMechanisms() {
+        return offeredMechanisms;
     }
 
     protected void closeAction() throws IOException {

--- a/src/main/java/org/jboss/remoting3/spi/ConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/spi/ConnectionHandler.java
@@ -24,6 +24,7 @@ package org.jboss.remoting3.spi;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Set;
 
 import javax.net.ssl.SSLSession;
 
@@ -93,6 +94,13 @@ public interface ConnectionHandler extends HandleableCloseable<ConnectionHandler
      * @return {@code true} if remote authentication is supported, {@code false} otherwise
      */
     boolean supportsRemoteAuth();
+
+    /**
+     * Get the available SASL mechanisms.
+     *
+     * @return the available SASL mechanisms
+     */
+    Set<String> getOfferedMechanisms();
 
     /**
      * Send an authentication request.


### PR DESCRIPTION
Currently, we're ending up using the client's ```authenticationFactory.getMechanisms()``` method to determine the available mechanisms. We need to keep track of the SASL mechanisms that were offered by the server. 