### PR TITLE
[REM3-253] Update ConnectionPeerIdentityContext so that the peer identity IDs used for connectionIdentity and anonymousIdentity are consistent with the Javadoc for Connection.getPeerIdentityId()

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
@@ -67,8 +67,8 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
     ConnectionPeerIdentityContext(final ConnectionImpl connection, final Collection<String> offeredMechanisms) {
         this.connection = connection;
         this.offeredMechanisms = offeredMechanisms == null ? Collections.emptySet() : offeredMechanisms;
-        anonymousIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, AnonymousPrincipal.getInstance(), 0, connection));
-        connectionIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, connection.getPrincipal(), 1, connection));
+        connectionIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, connection.getPrincipal(), 0, connection));
+        anonymousIdentity = constructIdentity(conf -> new ConnectionPeerIdentity(conf, AnonymousPrincipal.getInstance(), 1, connection));
     }
 
     /**


### PR DESCRIPTION
https://issues.jboss.org/browse/REM3-253