### PR TITLE
[REM3-254] Fix ConnectionImpl.supportsRemoteAuth() and add a supportsRemoteAuth() method to the Connection interface

### DIFF
--- a/src/main/java/org/jboss/remoting3/Connection.java
+++ b/src/main/java/org/jboss/remoting3/Connection.java
@@ -179,4 +179,11 @@ public interface Connection extends HandleableCloseable<Connection>, Attachable 
      * @return the peer principal (must not be {@code null})
      */
     Principal getPrincipal();
+
+    /**
+     * Determine if the remote authentication protocol is supported by this connection.
+     *
+     * @return {@code true} if remote authentication is supported, {@code false} otherwise
+     */
+    boolean supportsRemoteAuth();
 }

--- a/src/main/java/org/jboss/remoting3/ConnectionImpl.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionImpl.java
@@ -171,7 +171,8 @@ class ConnectionImpl extends AbstractHandleableCloseable<Connection> implements 
         return peerIdentityContext;
     }
 
-    boolean supportsRemoteAuth() {
+    @Override
+    public boolean supportsRemoteAuth() {
         return connectionHandler.supportsRemoteAuth();
     }
 

--- a/src/main/java/org/jboss/remoting3/ConnectionImpl.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionImpl.java
@@ -172,7 +172,7 @@ class ConnectionImpl extends AbstractHandleableCloseable<Connection> implements 
     }
 
     boolean supportsRemoteAuth() {
-        return getPeerIdentityContext() != null;
+        return connectionHandler.supportsRemoteAuth();
     }
 
     public Principal getPrincipal() {

--- a/src/main/java/org/jboss/remoting3/ManagedConnection.java
+++ b/src/main/java/org/jboss/remoting3/ManagedConnection.java
@@ -140,4 +140,8 @@ final class ManagedConnection implements Connection {
     public Principal getPrincipal() {
         return delegate.getPrincipal();
     }
+
+    public boolean supportsRemoteAuth() {
+        return delegate.supportsRemoteAuth();
+    }
 }


### PR DESCRIPTION
While doing some sanity tests with wildfly-naming-client and a legacy server, I ran into an AuthenticationException in [ConnectionPeerIdentityContext.authenticate()](https://github.com/jboss-remoting/jboss-remoting/blob/master/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java#L88) since the legacy server doesn't support remote authentication. This PR adds a ```supportsRemoteAuth()``` method to the Connection interface and makes the existing implementation of this method in ```ConnectionImpl``` public. This method could then be used from [RemoteNamingProvider.getPeerIdentity()](https://github.com/wildfly/wildfly-naming-client/blob/master/src/main/java/org/wildfly/naming/client/remote/RemoteNamingProvider.java#L126) to check if remote authentication is supported prior to calling ```ConnectionPeerIdentityContext.authenticate()```, i.e., something like:

```
public ConnectionPeerIdentity getPeerIdentity() throws AuthenticationException, IOException {
    final Connection connection = connectionFactory.get().get();
    if (connection.supportsRemoteAuth()) {
        return connection.getPeerIdentityContext().authenticate(authenticationConfiguration);
    } else {
        return connection.getConnectionPeerIdentity();
    }
}
```

WDYT?
