### PR TITLE
[REM3-262] SSL EJB Client stuck in AbstractHandleableCloseable.close

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
@@ -281,30 +281,36 @@ final class RemoteConnection {
         }
 
         public void shutdownWrites() {
-            synchronized (queue) {
-                closed = true;
-                terminateHeartbeat();
-                final ConnectedMessageChannel channel = getChannel();
-                try {
-                    if (! queue.isEmpty()) {
-                        channel.resumeWrites();
-                        return;
-                    }
-                    channel.shutdownWrites();
-                    if (! channel.flush()) {
-                        channel.resumeWrites();
-                        return;
-                    }
-                    RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Shut down writes on channel");
-                } catch (IOException e) {
-                    handleException(e, false);
-                    channel.wakeupReads();
-                    Pooled<ByteBuffer> unqueued;
-                    while ((unqueued = queue.poll()) != null) {
-                        unqueued.free();
+            channel.getIoThread().execute(new Runnable() {
+                @Override
+                public void run() {
+
+                    synchronized (queue) {
+                        closed = true;
+                        terminateHeartbeat();
+                        final ConnectedMessageChannel channel = getChannel();
+                        try {
+                            if (! queue.isEmpty()) {
+                                channel.resumeWrites();
+                                return;
+                            }
+                            channel.shutdownWrites();
+                            if (! channel.flush()) {
+                                channel.resumeWrites();
+                                return;
+                            }
+                            RemoteLogger.conn.logf(FQCN, Logger.Level.TRACE, null, "Shut down writes on channel");
+                        } catch (IOException e) {
+                            handleException(e, false);
+                            channel.wakeupReads();
+                            Pooled<ByteBuffer> unqueued;
+                            while ((unqueued = queue.poll()) != null) {
+                                unqueued.free();
+                            }
+                        }
                     }
                 }
-            }
+            });
         }
 
         public void send(final Pooled<ByteBuffer> pooled, final boolean close) {


### PR DESCRIPTION
the sequence send close flag and shutdown writes must be serialized.
The send flag must always be sent before shutdown writes sets
the closed boolean to false otherwise send method will never send the 
flag to the server as it checks this flag.

7.0.z https://issues.jboss.org/browse/JBEAP-8577
upstream: https://github.com/jboss-remoting/jboss-remoting/pull/102