### PR TITLE
"Workaround" for closing native remoting connection leaks

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
@@ -309,6 +309,7 @@ final class RemoteConnection {
                             channel.shutdownWrites();
                             if (channel.flush()) {
                                 Messages.conn.trace("Shut down writes on channel");
+                                connection.close();
                                 return;
                             }
                             // either this is successful and no more notifications will come, or not and it will be retried


### PR DESCRIPTION
This probably shouldn't get merged as the fix, but it is a workaround I want to show @dmlloyd.

The issue here is really quite odd. Currently using remote:// doesn't use TLS (its configured in EndPoint to not use it) but still involves JsseConnection. Because TLS never starts, JsseStreamConduit.performIO() is never called in JsseStreamConduit, and close ends up never being called.

The really weird part is that close() only ends up being called by throwing ConnectionClosedException() in JsseStreamConnection.performIO(), which ends up calling handleException and closing the underlying connection ... which isn't exactly the expected route. This is currently how remoting:// is closing its connections. I'll have another look at JsseStreamConduit and see if I can see whats going on.