### PR TITLE
Fix for REM3-222. NPE in IntIndexHashMap

### DIFF
--- a/src/main/java/org/jboss/remoting3/_private/IntIndexHashMap.java
+++ b/src/main/java/org/jboss/remoting3/_private/IntIndexHashMap.java
@@ -446,8 +446,9 @@ public final class IntIndexHashMap<V> extends AbstractCollection<V> implements I
         for (int i = 0; i < origCapacity; i ++) {
             // for each row, try to resize into two new rows
             V[] origRow, newRow0, newRow1;
-            int count0 = 0, count1 = 0;
+            int count0, count1;
             do {
+                count0 = count1 = 0;
                 origRow = origArray.get(i);
                 if (origRow != null) {
                     for (V item : origRow) {


### PR DESCRIPTION
When resizing, the table could contain null item inside row. This change of initialisation (that needs to be done in any cases) seems to fix this random failure. 
A manual reproducer that is failing 2/3 times over 10 run seems to no more fail with this fix.
