### PR TITLE
[BZ-1335299] [GSS] (6.4.z) remotingjmx client fails to work when the …

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
@@ -32,12 +32,15 @@ import java.nio.ByteBuffer;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.GeneralSecurityException;
+import java.security.KeyStore;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
 import javax.security.auth.callback.CallbackHandler;
 
 import java.util.Set;
@@ -57,6 +60,7 @@ import org.xnio.ChannelListener;
 import org.xnio.FutureResult;
 import org.xnio.IoFuture;
 import org.xnio.IoUtils;
+import org.xnio.Option;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Pool;
@@ -204,7 +208,32 @@ final class RemoteConnectionProvider extends AbstractHandleableCloseable<Connect
         if (useSsl && destination instanceof InetSocketAddress) {
             if (xnioSsl == null) {
                 try {
-                    xnioSsl = xnio.getSslProvider(connectOptions);
+                    Boolean usePKCS = connectOptions.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_USEPKCS, false);
+                    String keyStorePassword = connectOptions.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_KEYSTOREPASSWORD, "");
+                    String sslProtocol = connectOptions.get(RemoteConnectionProviderFactory.JBOSS_AS_REMOTE_SSLPROTOCOL, "");
+                    if(usePKCS) {
+                        KeyStore ks = KeyStore.getInstance("PKCS11");
+                        ks.load(null, keyStorePassword.toCharArray());
+                        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                        tmf.init(ks);
+                        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                        kmf.init(ks, (char[]) null);
+
+                        OptionMap.Builder builder = OptionMap.builder();
+                        for (Option o : connectOptions) {
+                            builder.set(o, connectOptions.get(o));
+                        }
+                        builder.set(Options.SSL_PROTOCOL, sslProtocol);
+
+                        xnioSsl = xnio.getSslProvider(kmf.getKeyManagers(), tmf.getTrustManagers(), builder.getMap());
+
+                    } else {
+
+                        xnioSsl = xnio.getSslProvider(connectOptions);
+                    }
+                } catch (IOException e) {
+                    result.setException(sslConfigFailure(e));
+                    return IoUtils.nullCancellable();
                 } catch (GeneralSecurityException e) {
                     result.setException(sslConfigFailure(e));
                     return IoUtils.nullCancellable();
@@ -318,6 +347,10 @@ final class RemoteConnectionProvider extends AbstractHandleableCloseable<Connect
     }
 
     private static IOException sslConfigFailure(final GeneralSecurityException e) {
+        return new IOException("Failed to configure SSL", e);
+    }
+
+    private static IOException sslConfigFailure(final IOException e) {
         return new IOException("Failed to configure SSL", e);
     }
 

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProviderFactory.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProviderFactory.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 import org.jboss.remoting3.spi.ConnectionProvider;
 import org.jboss.remoting3.spi.ConnectionProviderContext;
 import org.jboss.remoting3.spi.ConnectionProviderFactory;
+import org.xnio.Option;
 import org.xnio.OptionMap;
+import org.xnio.Options;
 
 /**
  * A {@link ConnectionProviderFactory} for the {@code remote} protocol.
@@ -34,6 +36,22 @@ import org.xnio.OptionMap;
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class RemoteConnectionProviderFactory implements ConnectionProviderFactory {
+
+    /**
+     * Flag, wheter use PKCS11 keystore in jboss-remoting.
+     */
+    public static final Option<Boolean> JBOSS_AS_REMOTE_USEPKCS = Option.simple(Options.class, "JBOSS_AS_REMOTE_USEPKCS", Boolean.class);
+
+    /**
+     * Keystore password for the PKCS11 keystore for jboss-remoting.
+     */
+    public static final Option<String> JBOSS_AS_REMOTE_KEYSTOREPASSWORD = Option.simple(Options.class, "JBOSS_AS_REMOTE_KEYSTOREPASSWORD", String.class);
+
+    /**
+     * SSL protocol for the PKCS11 keystore for jboss-remoting.
+     */
+    public static final Option<String> JBOSS_AS_REMOTE_SSLPROTOCOL= Option.simple(Options.class, "JBOSS_AS_REMOTE_SSLPROTOCOL", String.class);
+
 
     /**
      * Construct a new instance.


### PR DESCRIPTION
…JVM is running in FIPS mode

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1335299
Upstream (EAP 7.0): https://issues.jboss.org/browse/JBEAP-4587
Upstream (EAP 7.1, WF): https://issues.jboss.org/browse/REMJMX-142
PR (EAP 7.0): https://github.com/jboss-remoting/jboss-remoting/pull/114
                        https://github.com/jbossas/remoting-jmx/pull/30
PR (EAP 7.1, WF): jbossas/remoting-jmx@fdf793a