### PR TITLE
REM3-270 AuthenticationConfiguration protocol is not being used

### DIFF
--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -526,7 +526,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
         if (sm != null) {
             sm.checkPermission(RemotingPermission.CONNECT);
         }
-        final String scheme = destination.getScheme();
+        final String scheme = AUTH_CONFIGURATION_CLIENT.getRealProtocol(destination, configuration);
         synchronized (connectionLock) {
             boolean ok = false;
             try {


### PR DESCRIPTION
An addition to your previous commit https://github.com/jboss-remoting/jboss-remoting/commit/166d482a74feae805dd9425a30ebd3164c0f01c9

https://issues.jboss.org/browse/REM3-270
https://issues.jboss.org/browse/JBEAP-10544