### PR TITLE
REM3-284 JMX client hangs when closing an unresponsive connection

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -587,6 +587,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     protected void closeAction() throws IOException {
         sendCloseRequest();
         remoteConnection.shutdownWrites();
+        remoteConnection.getMessageReader().shutdownReads();
         // now these guys can't send useless messages
         closePendingChannels();
         closeAllChannels();


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/REM3-284
