### PR TITLE
REM3-284 JMX client hangs when closing an unresponsive connection

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -419,6 +419,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     protected void closeAction() throws IOException {
         sendCloseRequest();
         remoteConnection.shutdownWrites();
+        IoUtils.safeShutdownReads(remoteConnection.getChannel());
         // now these guys can't send useless messages
         closePendingChannels();
         closeAllChannels();


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/REM3-284