### PR TITLE
BZ-1454564 JMX client hangs when closing an unresponsive connection

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -419,6 +419,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     protected void closeAction() throws IOException {
         sendCloseRequest();
         remoteConnection.shutdownWrites();
+        IoUtils.safeShutdownReads(remoteConnection.getChannel());
         // now these guys can't send useless messages
         closePendingChannels();
         closeAllChannels();


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1454564
Wildfly/EAP 7.x: https://issues.jboss.org/browse/WFCORE-2916
EAP 7.0.x: https://issues.jboss.org/browse/JBEAP-11346

PRs:
Wildfly/EAP 7.x: https://github.com/jboss-remoting/jboss-remoting/pull/118
EAP 7.0.x: https://github.com/jboss-remoting/jboss-remoting/pull/119

