### PR TITLE
JBEAP-11643 throw SaslException if failedMechs is not empty instead o…

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/ClientConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ClientConnectionOpenListener.java
@@ -258,6 +258,10 @@ final class ClientConnectionOpenListener implements ChannelListener<ConduitStrea
                 return;
             }
             if (message == MessageReader.EOF_MARKER) {
+                if(!failedMechs.isEmpty()){
+                    connection.handleException(allMechanismsFailed());
+                    return;
+                }
                 connection.handleException(client.abruptClose(connection));
                 return;
             }


### PR DESCRIPTION
…f calling abruptClose to throw IOException.

https://issues.jboss.org/browse/JBEAP-11643
Fix the problem that providing wrong password in PLAIN mechanism, it throws simple IOException instead of expected SaslException.