### PR TITLE
REM3-277: Fix problem with SASL protocol property when options are being merged into AuthenticationConfiguration

### DIFF
--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -70,7 +70,6 @@ import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
 import org.wildfly.security.auth.server.SaslAuthenticationFactory;
-import org.wildfly.security.sasl.util.PrivilegedSaslClientFactory;
 import org.wildfly.security.sasl.util.ProtocolSaslClientFactory;
 import org.wildfly.security.sasl.util.ServerNameSaslClientFactory;
 
@@ -512,7 +511,9 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
     IoFuture<Connection> connect(final URI destination, final SocketAddress bindAddress, final OptionMap connectOptions, final AuthenticationConfiguration configuration, final SSLContext sslContext) {
         Assert.checkNotNullParam("destination", destination);
         Assert.checkNotNullParam("connectOptions", connectOptions);
-        final String protocol = connectOptions.contains(RemotingOptions.SASL_PROTOCOL) ? connectOptions.get(RemotingOptions.SASL_PROTOCOL) : RemotingOptions.DEFAULT_SASL_PROTOCOL;
+        final String protocol =  AUTH_CONFIGURATION_CLIENT.getSaslProtocol(configuration) != null ? AUTH_CONFIGURATION_CLIENT.getSaslProtocol(configuration)
+                : connectOptions.contains(RemotingOptions.SASL_PROTOCOL) ? connectOptions.get(RemotingOptions.SASL_PROTOCOL)
+                : RemotingOptions.DEFAULT_SASL_PROTOCOL;
         UnaryOperator<SaslClientFactory> factoryOperator = factory -> new ProtocolSaslClientFactory(factory, protocol);
         if (connectOptions.contains(RemotingOptions.SERVER_NAME)) {
             final String serverName = connectOptions.get(RemotingOptions.SERVER_NAME);

--- a/src/main/java/org/jboss/remoting3/RemotingOptions.java
+++ b/src/main/java/org/jboss/remoting3/RemotingOptions.java
@@ -56,10 +56,9 @@ public final class RemotingOptions {
         Assert.checkNotNullParam("optionMap", optionMap);
         Assert.checkNotNullParam("authenticationConfiguration", authenticationConfiguration);
 
-        final String protocol = optionMap.get(SASL_PROTOCOL);
-        if (protocol != null) {
-            authenticationConfiguration = authenticationConfiguration.useProtocol(protocol);
-        }
+        final String saslProtocol = optionMap.get(SASL_PROTOCOL);
+        authenticationConfiguration = authenticationConfiguration.useSaslProtocol(saslProtocol != null ? saslProtocol : RemotingOptions.DEFAULT_SASL_PROTOCOL);
+
         final String realm = optionMap.get(AUTH_REALM);
         if (realm != null) {
             authenticationConfiguration = authenticationConfiguration.useRealm(realm);


### PR DESCRIPTION
`remote.connection.node1.connect.options.org.xnio.Options.SASL_PROTOCOL` property was being used to configure the protocol in AuthenticationConfiguration, which is used to change the outgoing protocol connection. According to java docs of SASL_PROTOCOL, this property has to be used only to configure the SaslClient and SaslServer protocol. This patch tries to resolve this mismatch. It requires an update from wildfly-elytron

Jira issues:
https://issues.jboss.org/browse/REM3-277
https://issues.jboss.org/browse/JBEAP-10996

It depends on https://github.com/wildfly-security/wildfly-elytron/pull/888