### PR TITLE
Added JaCoCo profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <junit.version>4.8.2</junit.version>
         <byteman-version>2.2.0.1</byteman-version>
         <threads.version>2.2.1.Final</threads.version>
+        <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <test.level>INFO</test.level>
         <leak.debug>false</leak.debug>
 
@@ -389,4 +390,149 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jacoco</id>
+            <activation>
+                <property>
+                    <name>jacoco</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jacoco-prepare</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
+                                    <propertyName>surefireArgLine</propertyName>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>jacoco-prepare-it</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>prepare-agent-integration</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
+                                    <propertyName>jacoco.agent</propertyName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>${surefireArgLine}</argLine>
+                            <skipTests>false</skipTests>
+                            <systemPropertyVariables>
+                                <jacoco.agent>@{jacoco.agent}</jacoco.agent>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jacoco-generate-report</id>
+            <activation>
+                <property>
+                    <name>jacoco.generate.report</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <phase>process-test-resources</phase>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.jacoco</groupId>
+                                            <artifactId>org.jacoco.ant</artifactId>
+                                            <version>${jacoco-maven-plugin.version}</version></artifactItem>
+                                    </artifactItems>
+                                    <stripVersion>true</stripVersion>
+                                    <outputDirectory>${project.build.directory}/jacoco-jars</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.ant</artifactId>
+                                <version>${jacoco-maven-plugin.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <inherited>false</inherited>
+                                <configuration>
+                                    <target>
+                                        <property name="result.report.dir" location="${project.build.directory}/jacoco-report"/>
+                                        <taskdef name="report" classname="org.jacoco.ant.ReportTask">
+                                            <classpath path="${project.build.directory}/jacoco-jars/org.jacoco.ant.jar"/>
+                                        </taskdef>
+                                        <echo>Creating JaCoCo Remoting test coverage reports...</echo>
+                                        <report>
+                                            <executiondata>
+                                                <fileset dir="${project.build.directory}">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                            </executiondata>
+                                            <structure name="JaCoCo Remoting">
+                                                <classfiles>
+                                                    <fileset dir="${project.build.directory}">
+                                                        <include name="**/jboss-remoting*.jar"/>
+                                                    </fileset>
+                                                </classfiles>
+                                                <sourcefiles encoding="UTF-8">
+                                                    <fileset dir="${project.build.directory}/../src">
+                                                        <include name="**/*.java"/>
+                                                    </fileset>
+                                                </sourcefiles>
+                                            </structure>
+                                            <html destdir="\${result.report.dir}"/>
+                                            <xml destfile="\${result.report.dir}/report.xml"/>
+                                        </report>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
If you're willing to include this, I added two new profiles - one generates jacoco.exec (activated with `-Djacoco`) file, the other generates html and xml reports (activated with `-Djacoco.generate.report`).

It's useful for EAP QE, but if you don't want to include it for whatever reason, we can go without it.

Thanks!
(rjanik)