### PR TITLE
[REM3-297] Ensure unexpected exceptions that occur during SASL authentication get handled properly

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
@@ -285,7 +285,7 @@ final class ServerConnectionOpenListener  implements ChannelListener<ConduitStre
                                 saslServerFactory = saslProperties != null ? new PropertiesSaslServerFactory(saslServerFactory, saslProperties) : saslServerFactory;
                                 return saslServerFactory;
                             });
-                        } catch (SaslException e) {
+                        } catch (Throwable e) {
                             server.trace("Unable to create SaslServer", e);
                             saslServer = null;
                         }


### PR DESCRIPTION
https://issues.jboss.org/browse/REM3-297
https://issues.jboss.org/browse/JBEAP-12745

Note: Although JBEAP-12745 is not a blocker issue, it does have the "eap7.1-ok-for-CR1" label.