### PR TITLE
Revert "REM3-284 JMX client hangs when closing an unresponsive connec…

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -419,7 +419,6 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     protected void closeAction() throws IOException {
         sendCloseRequest();
         remoteConnection.shutdownWrites();
-        IoUtils.safeShutdownReads(remoteConnection.getChannel());
         // now these guys can't send useless messages
         closePendingChannels();
         closeAllChannels();


### PR DESCRIPTION
…tion"

This reverts commit dfd27339edbb66796279b87012e61c70b073a760.

https://issues.jboss.org/browse/JBEAP-12105

It appears this commit is causing frequent hanging, even when READ_TIMEOUT is set, usually preceded by exception similar to this:

```
11:14:31,107 ERROR [org.xnio.ChannelListeners:94] XNIO001007: A channel event listener threw an exception
--
java.lang.IndexOutOfBoundsException
at java.nio.Buffer.checkIndex(Buffer.java:540)
at java.nio.DirectByteBuffer.get(DirectByteBuffer.java:253)
at sun.security.ssl.EngineInputRecord.read(EngineInputRecord.java:380)
at sun.security.ssl.SSLEngineImpl.readRecord(SSLEngineImpl.java:962)
at sun.security.ssl.SSLEngineImpl.readNetRecord(SSLEngineImpl.java:907)
at sun.security.ssl.SSLEngineImpl.unwrap(SSLEngineImpl.java:781)
at org.xnio.ssl.JsseStreamConduit.performIO(JsseStreamConduit.java:1377)
at org.xnio.ssl.JsseStreamConduit.terminateWrites(JsseStreamConduit.java:642)
at org.xnio.conduits.ConduitStreamSinkChannel.shutdownWrites(ConduitStreamSinkChannel.java:178)
at org.xnio.channels.AssembledStreamChannel.shutdownWrites(AssembledStreamChannel.java:184)
at org.xnio.channels.TranslatingSuspendableChannel.shutdownWritesAction(TranslatingSuspendableChannel.java:744)
at org.xnio.channels.TranslatingSuspendableChannel.shutdownWrites(TranslatingSuspendableChannel.java:733)
at org.jboss.remoting3.remote.RemoteConnection$RemoteWriteListener.handleEvent(RemoteConnection.java:262)
at org.jboss.remoting3.remote.RemoteConnection$RemoteWriteListener.handleEvent(RemoteConnection.java:217)
at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
at org.xnio.channels.TranslatingSuspendableChannel.handleWritable(TranslatingSuspendableChannel.java:252)
at org.xnio.channels.TranslatingSuspendableChannel$2.handleEvent(TranslatingSuspendableChannel.java:122)
at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
at org.xnio.ChannelListeners$DelegatingChannelListener.handleEvent(ChannelListeners.java:1092)
at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
at org.xnio.conduits.WriteReadyHandler$ChannelListenerHandler.writeReady(WriteReadyHandler.java:65)
at org.xnio.ssl.JsseStreamConduit.run(JsseStreamConduit.java:393)
at org.xnio.nio.WorkerThread.safeRun(WorkerThread.java:592)
at org.xnio.nio.WorkerThread.run(WorkerThread.java:472)
```

It seems wrong to shutdown reads before close handshake is completed.

The commit was introduced into EAP 7.0.7 and since then at least two customer cases were opened, describing this issue (01667616, 01893519). In 01893519 customer was kind enough to test modified jboss-remoting library, which included this revert, and confirmed that he didn't experience the hanging anymore.

I would value any input from remoting team.

Note to self and @jurakp: if this is merged, issues related to REM3-284 need to be reopened.