### PR TITLE
REM3-300 Fix exception handling in RemoteConnectionHandler

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -419,7 +419,7 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     protected void closeAction() throws IOException {
         sendCloseRequest();
         remoteConnection.shutdownWrites();
-        IoUtils.safeShutdownReads(remoteConnection.getChannel());
+        remoteConnection.getChannel().shutdownReads();
         // now these guys can't send useless messages
         closePendingChannels();
         closeAllChannels();


### PR DESCRIPTION
https://issues.jboss.org/browse/REM3-300
https://issues.jboss.org/browse/JBEAP-12105

master PR: https://github.com/jboss-remoting/jboss-remoting/pull/138
4.x PR: https://github.com/jboss-remoting/jboss-remoting/pull/140
4.0 PR: https://github.com/jboss-remoting/jboss-remoting/pull/139

This adds some error handling to AbstractHandleableCloseable.closeAsync(), some kind of error handling already is in AbstractHandleableCloseable.close().