### PR TITLE
REM3-305 Remoting messages might not be processed in some edge cases

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/MessageReader.java
+++ b/src/main/java/org/jboss/remoting3/remote/MessageReader.java
@@ -102,8 +102,13 @@ final class MessageReader {
                                         first.putInt(next.getInt());
                                     } else {
                                         Buffers.copy(first, next);
+                                        iterator.remove(); //we have emptied the buffer so we remove it
                                     }
                                 } while (first.position() < 4 && iterator.hasNext());
+                                if(first.position() >= 4) {
+                                    //we have enough to read the size, retry rather than attempting to read from the channel
+                                    continue;
+                                }
                             } finally {
                                 first.flip();
                             }

--- a/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
@@ -95,11 +95,11 @@ final class RemoteReadListener implements ChannelListener<ConduitStreamSourceCha
                         case Protocol.CONNECTION_ALIVE: {
                             log.trace("Received connection alive");
                             connection.sendAliveResponse();
-                            return;
+                            break;
                         }
                         case Protocol.CONNECTION_ALIVE_ACK: {
                             log.trace("Received connection alive ack");
-                            return;
+                            break;
                         }
                         case Protocol.CONNECTION_CLOSE: {
                             log.trace("Received connection close request");


### PR DESCRIPTION
If the MessageReader reads two or more messages, and a message is split over the buffers such that 3 or less bytes are in the first buffer it is possible that the message will not be processed until further messages arrive over the wire.