### PR TITLE
[BZ1491965] : Reworked REM3-259 + revert of 1cb79d7ce7bbf4eb94d402ea9bdef5d63d435af6 : CLI with 2-way SSL often hangs/times out

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionHandler.java
@@ -419,7 +419,6 @@ final class RemoteConnectionHandler extends AbstractHandleableCloseable<Connecti
     protected void closeAction() throws IOException {
         sendCloseRequest();
         remoteConnection.shutdownWrites();
-        IoUtils.safeShutdownReads(remoteConnection.getChannel());
         // now these guys can't send useless messages
         closePendingChannels();
         closeAllChannels();

--- a/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
@@ -64,7 +64,6 @@ import org.jboss.remoting3.spi.ConnectionHandler;
 import org.jboss.remoting3.spi.ConnectionHandlerContext;
 import org.jboss.remoting3.spi.ConnectionHandlerFactory;
 import org.jboss.remoting3.spi.ConnectionProviderContext;
-import org.xnio.BufferAllocator;
 import org.xnio.Buffers;
 import org.xnio.ChannelListener;
 import org.xnio.OptionMap;
@@ -222,21 +221,32 @@ final class ServerConnectionOpenListener  implements ChannelListener<ConnectedMe
         public void handleEvent(final ConnectedMessageChannel channel) {
             Pooled<ByteBuffer> pooledBuffer = connection.allocate();
             boolean free = true;
+            ByteBuffer receiveBuffer;
             try {
                 if (channel instanceof RemotingMessageChannel) {
-                    try {
-                        int messageLength = ((RemotingMessageChannel) channel).readMessageLength();
-                        if (messageLength > pooledBuffer.getResource().capacity() && messageLength < RemotingOptions.MAX_RECEIVE_BUFFER_SIZE) {
-                            pooledBuffer = Buffers.allocatedBufferPool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, messageLength).allocate();
-                            ((RemotingMessageChannel) channel).adjustToMessageLength(messageLength);
+                    synchronized (connection.getLock()) {
+                        int res;
+                        RemotingMessageChannel.AdjustedBuffer ab = new RemotingMessageChannel.AdjustedBuffer(pooledBuffer);
+                        try {
+                            RemotingMessageChannel rc = (RemotingMessageChannel) channel;
+                            res = rc.receive(ab);
+                        } catch (IOException e) {
+                            connection.handleException(e);
+                            return;
                         }
-                    } catch (IOException e) {
-                        connection.handleException(e);
-                        return;
+                        if (res == -1) {
+                            log.trace("Received connection end-of-stream");
+                            connection.handlePreAuthCloseRequest();
+                            return;
+                        }
+                        if (res == 0) {
+                            return;
+                        }
+                        pooledBuffer = ab.getAdjustedBuffer();
+                        receiveBuffer = pooledBuffer.getResource();
                     }
-                }
-
-                final ByteBuffer receiveBuffer = pooledBuffer.getResource();
+                } else {
+                receiveBuffer = pooledBuffer.getResource();
                 synchronized (connection.getLock()) {
                     final int res;
                     try {
@@ -253,6 +263,7 @@ final class ServerConnectionOpenListener  implements ChannelListener<ConnectedMe
                         connection.handlePreAuthCloseRequest();
                         return;
                     }
+                }
                 }
                 receiveBuffer.flip();
                 final byte msgType = receiveBuffer.get();


### PR DESCRIPTION
[BZ1491965] : https://bugzilla.redhat.com/show_bug.cgi?id=1491965
[REM3-308] : https://issues.jboss.org/browse/REM3-308
[Upstream] : Not required