### PR TITLE
[REM3-314] Fix processing of the SASL server success message for shared-connection authentication

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
@@ -305,7 +305,7 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
                         }
                         // retry loop
                     } else if (status == SUCCESS) {
-                        if (challenge != null) {
+                        if (! saslClient.isComplete()) {
                             try {
                                 response = saslClient.evaluateChallenge(challenge);
                             } catch (SaslException e) {
@@ -315,7 +315,7 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
                                 safeDispose(saslClient);
                                 break;
                             }
-                            if (response != null) {
+                            if (response != null && response.length > 0) {
                                 try {
                                     connectionHandler.sendAuthDelete(id);
                                 } catch (IOException ignored) {

--- a/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
@@ -327,11 +327,10 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
                                 return;
                             }
                         }
+                        final Object principalObj = saslClient.getNegotiatedProperty(WildFlySasl.PRINCIPAL);
                         safeDispose(saslClient);
                         // todo: we could use a phantom ref to clean up the ID, but the benefits are dubious
-                        final SaslClient finalSaslClient = saslClient;
                         futureResult.setResult(constructIdentity(conf -> {
-                            final Object principalObj = finalSaslClient.getNegotiatedProperty(WildFlySasl.PRINCIPAL);
                             return new ConnectionPeerIdentity(conf, principalObj instanceof Principal ? (Principal) principalObj : principal, finalId, connection);
                         }));
                         return;

--- a/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
@@ -479,8 +479,7 @@ final class RemoteReadListener implements ChannelListener<ConduitStreamSourceCha
                                 saslBytes = new byte[buffer.remaining()];
                                 buffer.get(saslBytes);
                             } else {
-                                // in this case null is OK meaning the process is finished
-                                saslBytes = null;
+                                saslBytes = NO_BYTES;
                             }
                             c.receiveAuthSuccess(id, saslBytes);
                             break;


### PR DESCRIPTION
This PR fixes the hang in ```org.wildfly.test.manual.elytron.seccontext.SecurityContextPropagationSLSFTestCase#testClientOauthbearerInsufficientRolesFails``` that started occurring with the changes for [ELY-1380](https://issues.jboss.org/browse/ELY-1380) by:
* ensuring that ```SaslClient.evaluateChallenge()``` gets called when processing the success message from the server if ```SaslClient.isComplete()``` returns false
* ensuring that ```getNegotiatedProperty()``` is called before ```dispose()``` is called on the ```SaslClient``` in ```ConnectionPeerIdentityContext#doAuthenticate```

Note that these two changes for shared-connection authentication are similar to what is currently done for initial connection establishment.

For more details on this, see:

https://issues.jboss.org/browse/REM3-314