### PR TITLE
[REM3-326] remove final from interface params

### DIFF
--- a/src/main/java/org/jboss/remoting3/Endpoint.java
+++ b/src/main/java/org/jboss/remoting3/Endpoint.java
@@ -380,7 +380,19 @@ public interface Endpoint extends HandleableCloseable<Endpoint>, Attachable, Con
      */
     IoFuture<Connection> connect(URI destination, InetSocketAddress bindAddress, OptionMap connectOptions, SSLContext sslContext, AuthenticationConfiguration connectionConfiguration);
 
-    IoFuture<Connection> connect(final URI destination, final OptionMap connectOptions, final CallbackHandler callbackHandler) throws IOException;
+    /**
+     * Open an unshared connection with a peer.  Returns a future connection which may be used to cancel the connection attempt.
+     * This method does not block; use the return value to wait for a result if you wish to block.
+     * <p/>
+     * You must have the {@link RemotingPermission connect EndpointPermission} to invoke this method.
+     *
+     * @param destination the destination
+     * @param connectOptions options to configure this connection
+     * @param callbackHandler the local callback handler to use for authentication
+     * @return the future connection (not {@code null})
+     */
+    @Deprecated
+    IoFuture<Connection> connect(URI destination, OptionMap connectOptions, CallbackHandler callbackHandler) throws IOException;
 
     /**
      * Register a connection provider for a URI scheme.  The provider factory is called with the context which can


### PR DESCRIPTION
https://issues.jboss.org/browse/REM3-326
Fix the finals in the Endpoint that some how came back