### PR TITLE
[REM3-331] Configure the hearbeat timeout by default for auto creat…

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionBuilder.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionBuilder.java
@@ -23,41 +23,40 @@ import java.net.URI;
 import org.wildfly.common.Assert;
 
 /**
- * A builder for configuring a preconfigured endpoint connection.
+ * A builder for configuring a preconfigured endpoint connection. Some values are set to defaults to make sure
+ * a heartbeat is always sent.
  *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class ConnectionBuilder {
     private final URI destination;
 
-    private int readTimeout = -1; // millis
-    private int writeTimeout = -1; // millis
+    private int readTimeout = RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2; // millis
+    private int writeTimeout = RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2; // millis
 
-    private boolean setTcpKeepAlive;
-    private boolean tcpKeepAlive;
+    private boolean tcpKeepAlive = true;
     private int ipTrafficClass = -1;
 
-    private int heartbeatInterval = -1;
+    private int heartbeatInterval = RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL;
 
     ConnectionBuilder(final URI destination) {
         this.destination = destination;
     }
 
     public ConnectionBuilder setReadTimeout(final int readTimeout) {
-        Assert.checkMinimumParameter("readTimeout", 1L, readTimeout);
+        Assert.checkMinimumParameter("readTimeout", 0L, readTimeout);
         this.readTimeout = readTimeout;
         return this;
     }
 
     public ConnectionBuilder setWriteTimeout(final int writeTimeout) {
-        Assert.checkMinimumParameter("writeTimeout", 1L, writeTimeout);
+        Assert.checkMinimumParameter("writeTimeout", 0L, writeTimeout);
         this.writeTimeout = writeTimeout;
         return this;
     }
 
     public ConnectionBuilder setTcpKeepAlive(final boolean tcpKeepAlive) {
         this.tcpKeepAlive = tcpKeepAlive;
-        setTcpKeepAlive = true;
         return this;
     }
 
@@ -67,7 +66,7 @@ public final class ConnectionBuilder {
     }
 
     public ConnectionBuilder setHeartbeatInterval(final int heartbeatInterval) {
-        Assert.checkMinimumParameter("heartbeatInterval", 1, heartbeatInterval);
+        Assert.checkMinimumParameter("heartbeatInterval", 0, heartbeatInterval);
         this.heartbeatInterval = heartbeatInterval;
         return this;
     }
@@ -82,10 +81,6 @@ public final class ConnectionBuilder {
 
     int getWriteTimeout() {
         return writeTimeout;
-    }
-
-    boolean isSetTcpKeepAlive() {
-        return setTcpKeepAlive;
     }
 
     boolean isTcpKeepAlive() {

--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -206,21 +206,14 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
         if (connectionBuilders != null) for (ConnectionBuilder connectionBuilder : connectionBuilders) {
             final URI destination = connectionBuilder.getDestination();
             final OptionMap.Builder optionBuilder = OptionMap.builder();
-            if (connectionBuilder.getHeartbeatInterval() != -1) {
-                optionBuilder.set(RemotingOptions.HEARTBEAT_INTERVAL, connectionBuilder.getHeartbeatInterval());
-            }
-            if (connectionBuilder.getReadTimeout() != -1) {
-                optionBuilder.set(Options.READ_TIMEOUT, connectionBuilder.getReadTimeout());
-            }
-            if (connectionBuilder.getWriteTimeout() != -1) {
-                optionBuilder.set(Options.WRITE_TIMEOUT, connectionBuilder.getWriteTimeout());
-            }
+
+            optionBuilder.set(RemotingOptions.HEARTBEAT_INTERVAL, connectionBuilder.getHeartbeatInterval());
+            optionBuilder.set(Options.READ_TIMEOUT, connectionBuilder.getReadTimeout());
+            optionBuilder.set(Options.WRITE_TIMEOUT, connectionBuilder.getWriteTimeout());
             if (connectionBuilder.getIPTrafficClass() != -1) {
                 optionBuilder.set(Options.IP_TRAFFIC_CLASS, connectionBuilder.getIPTrafficClass());
             }
-            if (connectionBuilder.isSetTcpKeepAlive()) {
-                optionBuilder.set(Options.KEEP_ALIVE, connectionBuilder.isTcpKeepAlive());
-            }
+            optionBuilder.set(Options.KEEP_ALIVE, connectionBuilder.isTcpKeepAlive());
             connectionOptions.put(destination, optionBuilder.getMap());
         }
 

--- a/src/main/java/org/jboss/remoting3/RemotingOptions.java
+++ b/src/main/java/org/jboss/remoting3/RemotingOptions.java
@@ -281,9 +281,10 @@ public final class RemotingOptions {
     public static final Option<Integer> HEARTBEAT_INTERVAL = Option.simple(RemotingOptions.class, "HEARTBEAT_INTERVAL", Integer.class);
 
     /**
-     * The default heartbeat interval.
+     * The default heartbeat interval, set to 60000 that way a heartbeat is always sent by default to prevent side effects of network failures,
+     * check REM-331 for more information.
      */
-    public static final int DEFAULT_HEARTBEAT_INTERVAL = Integer.MAX_VALUE;
+    public static final int DEFAULT_HEARTBEAT_INTERVAL = 60000;
 
     /**
      * The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown

--- a/src/main/java/org/jboss/remoting3/RemotingXmlParser.java
+++ b/src/main/java/org/jboss/remoting3/RemotingXmlParser.java
@@ -233,11 +233,11 @@ final class RemotingXmlParser {
                     break;
                 }
                 case "read-timeout": {
-                    readTimeout = reader.getIntAttributeValueResolved(i, 1, Integer.MAX_VALUE);
+                    readTimeout = reader.getIntAttributeValueResolved(i, 0, Integer.MAX_VALUE);
                     break;
                 }
                 case "write-timeout": {
-                    writeTimeout = reader.getIntAttributeValueResolved(i, 1, Integer.MAX_VALUE);
+                    writeTimeout = reader.getIntAttributeValueResolved(i, 0, Integer.MAX_VALUE);
                     break;
                 }
                 case "ip-traffic-class": {
@@ -250,7 +250,7 @@ final class RemotingXmlParser {
                     break;
                 }
                 case "heartbeat-interval": {
-                    heartbeatInterval = reader.getIntAttributeValueResolved(i, 1, Integer.MAX_VALUE);
+                    heartbeatInterval = reader.getIntAttributeValueResolved(i, 0, Integer.MAX_VALUE);
                     break;
                 }
                 default: {

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
@@ -311,7 +311,7 @@ final class RemoteConnection {
                             // either way we're done here
                             return;
                         } else {
-                            if (heartbeatInterval != Integer.MAX_VALUE) {
+                            if (heartbeatInterval != 0) {
                                 this.heartKey = channel.getWriteThread().executeAfter(heartbeatCommand, heartbeatInterval, TimeUnit.MILLISECONDS);
                             }
                         }

--- a/src/test/java/org/jboss/remoting3/ConnectionBuilderTestCase.java
+++ b/src/test/java/org/jboss/remoting3/ConnectionBuilderTestCase.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.remoting3;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.security.Security;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+import org.jboss.remoting3.test.Utils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+
+public class ConnectionBuilderTestCase {
+
+    protected static Endpoint endpoint;
+
+    @Rule
+    public TestName name = new TestName();
+
+    private static String providerName;
+
+    @BeforeClass
+    public static void doBeforeClass() {
+        final WildFlyElytronProvider provider = new WildFlyElytronProvider();
+        Security.addProvider(provider);
+        providerName = provider.getName();
+    }
+
+    @AfterClass
+    public static void doAfterClass() {
+        Security.removeProvider(providerName);
+    }
+
+    @Before
+    public void doBefore() {
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Running test %s", name.getMethodName());
+    }
+
+    @After
+    public void doAfter() {
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Finished test %s", name.getMethodName());
+    }
+
+    /**
+     * Tests that setting some values works.
+     * @throws Exception
+     */
+    @Test
+    public void setValuesTest() throws Exception {
+        // create endpoint
+        final EndpointBuilder endpointBuilder = Endpoint.builder();
+        URI uri = URI.create("remote+http://localhost:30123");
+        ConnectionBuilder connectionBuilder = endpointBuilder.addConnection(uri);
+        connectionBuilder.setHeartbeatInterval(500);
+        connectionBuilder.setReadTimeout(0);
+        connectionBuilder.setWriteTimeout(5000);
+        connectionBuilder.setTcpKeepAlive(false);
+        final XnioWorker.Builder workerBuilder = endpointBuilder.buildXnioWorker(Xnio.getInstance());
+        workerBuilder.setCoreWorkerPoolSize(4).setMaxWorkerPoolSize(4).setWorkerIoThreads(4);
+        endpointBuilder.setEndpointName("test");
+
+        Endpoint ep = endpointBuilder.build();
+
+        Map<URI, OptionMap> connectionOptions = (Map<URI, OptionMap>) Utils.getInstanceValue(ep, "connectionOptions");
+        OptionMap optionMap = connectionOptions.get(uri);
+
+        assertEquals("Wrong value for readtimeout", 0, optionMap.get(Options.READ_TIMEOUT, 5));
+        assertEquals("Wrong value for writetimeout", 5000, optionMap.get(Options.WRITE_TIMEOUT, 5));
+        assertEquals("Wrong value for heartbeat", 500, optionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, 5));
+        assertEquals("Wrong value for keep_alive", false, optionMap.get(Options.KEEP_ALIVE, true));
+        ep.close();
+        ep = null;
+    }
+
+    /**
+     * Tests that uses the default values.
+     * @throws Exception
+     */
+    @Test
+    public void defaultValuesTest() throws Exception {
+        // create endpoint
+        final EndpointBuilder endpointBuilder = Endpoint.builder();
+        URI uri = URI.create("remote+http://localhost:30123");
+        endpointBuilder.addConnection(uri);
+        final XnioWorker.Builder workerBuilder = endpointBuilder.buildXnioWorker(Xnio.getInstance());
+        workerBuilder.setCoreWorkerPoolSize(4).setMaxWorkerPoolSize(4).setWorkerIoThreads(4);
+        endpointBuilder.setEndpointName("test");
+
+        Endpoint ep = endpointBuilder.build();
+
+        Map<URI, OptionMap> connectionOptions = (Map<URI, OptionMap>) Utils.getInstanceValue(ep, "connectionOptions");
+        OptionMap optionMap = connectionOptions.get(uri);
+
+        assertEquals("Wrong value for readtimeout", RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2, optionMap.get(Options.READ_TIMEOUT, 5));
+        assertEquals("Wrong value for writetimeout", RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2, optionMap.get(Options.WRITE_TIMEOUT, 5));
+        assertEquals("Wrong value for heartbeat", RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL, optionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, 5));
+        assertEquals("Wrong value for keep_alive", true, optionMap.get(Options.KEEP_ALIVE, false));
+        ep.close();
+        ep = null;
+    }
+
+}

--- a/src/test/java/org/jboss/remoting3/remote/HeartbeatTestCase.java
+++ b/src/test/java/org/jboss/remoting3/remote/HeartbeatTestCase.java
@@ -1,0 +1,274 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.remoting3.remote;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.PrivilegedAction;
+import java.security.Security;
+
+import javax.net.ssl.SSLContext;
+import javax.security.sasl.SaslServerFactory;
+
+import org.jboss.logging.Logger;
+import org.jboss.remoting3.Channel;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.OpenListener;
+import org.jboss.remoting3.Registration;
+import org.jboss.remoting3.RemotingOptions;
+import org.jboss.remoting3.remote.RemoteConnection.RemoteWriteListener;
+import org.jboss.remoting3.spi.NetworkServerProvider;
+import org.jboss.remoting3.test.Utils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.MechanismConfiguration;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.permission.PermissionVerifier;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+import org.wildfly.security.sasl.util.SaslMechanismInformation;
+import org.wildfly.security.sasl.util.ServiceLoaderSaslServerFactory;
+import org.xnio.FutureResult;
+import org.xnio.IoFuture;
+import org.xnio.IoUtils;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+
+/**
+ * Tests the heartbeat option.
+ *
+ * @author tmiyar
+ *
+ */
+public class HeartbeatTestCase {
+
+    private static String providerName;
+
+    @BeforeClass
+    public static void doBeforeClass() {
+        final WildFlyElytronProvider provider = new WildFlyElytronProvider();
+        Security.addProvider(provider);
+        providerName = provider.getName();
+    }
+
+    @AfterClass
+    public static void doAfterClass() {
+        Security.removeProvider(providerName);
+    }
+
+    @Before
+    public void doBefore() {
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Running test %s", name.getMethodName());
+    }
+
+    @After
+    public void doAfter() {
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Finished test %s", name.getMethodName());
+    }
+
+    @Rule
+    public TestName name = new TestName();
+
+    private void afterTest(Channel clientChannel, Channel serverChannel, Connection connection, Registration serviceRegistration) {
+        IoUtils.safeClose(clientChannel);
+        IoUtils.safeClose(serverChannel);
+        IoUtils.safeClose(connection);
+        serviceRegistration.close();
+    }
+
+    private void destroy(Endpoint endpoint, Closeable streamServer) throws IOException, InterruptedException {
+        IoUtils.safeClose(streamServer);
+        IoUtils.safeClose(endpoint);
+    }
+
+    /**
+     * Test that heartbeat can be set and can be disabled by setting it to 0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDisableHeartbeat() throws Exception {
+
+        Channel clientChannel = null;
+        Channel serverChannel = null;
+
+        Closeable streamServer = null;
+        Connection connection = null;
+        Registration serviceRegistration = null;
+
+        final Endpoint endpoint = Endpoint.builder().setEndpointName("test").build();
+        NetworkServerProvider networkServerProvider = endpoint.getConnectionProviderInterface("remote",
+                NetworkServerProvider.class);
+        final SecurityDomain.Builder domainBuilder = SecurityDomain.builder();
+        final SimpleMapBackedSecurityRealm mainRealm = new SimpleMapBackedSecurityRealm();
+        domainBuilder.addRealm("mainRealm", mainRealm).build();
+        domainBuilder.setDefaultRealmName("mainRealm");
+        domainBuilder.setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.ALL);
+        final PasswordFactory passwordFactory = PasswordFactory.getInstance("clear");
+        mainRealm.setPasswordMap("bob", passwordFactory.generatePassword(new ClearPasswordSpec("pass".toCharArray())));
+        final SaslServerFactory saslServerFactory = new ServiceLoaderSaslServerFactory(
+                HeartbeatTestCase.class.getClassLoader());
+        final SaslAuthenticationFactory.Builder builder = SaslAuthenticationFactory.builder();
+        builder.setSecurityDomain(domainBuilder.build());
+        builder.setFactory(saslServerFactory);
+        builder.setMechanismConfigurationSelector(mechanismInformation -> SaslMechanismInformation.Names.SCRAM_SHA_256
+                .equals(mechanismInformation.getMechanismName()) ? MechanismConfiguration.EMPTY : null);
+        final SaslAuthenticationFactory saslAuthenticationFactory = builder.build();
+        streamServer = networkServerProvider.createServer(new InetSocketAddress("localhost", 30123),
+                OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE), saslAuthenticationFactory, SSLContext.getDefault());
+
+        final FutureResult<Channel> passer = new FutureResult<Channel>();
+        serviceRegistration = endpoint.registerService("org.jboss.test", new OpenListener() {
+            public void channelOpened(final Channel channel) {
+                passer.setResult(channel);
+            }
+
+            public void registrationTerminated() {
+            }
+        }, OptionMap.EMPTY);
+        IoFuture<Connection> futureConnection = AuthenticationContext.empty()
+                .with(MatchRule.ALL,
+                        AuthenticationConfiguration.empty().useName("bob").usePassword("pass")
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("SCRAM-SHA-256")))
+                .run(new PrivilegedAction<IoFuture<Connection>>() {
+                    public IoFuture<Connection> run() {
+                        try {
+                            return endpoint.connect(new URI("remote://localhost:30123"),
+                                    OptionMap.create(RemotingOptions.HEARTBEAT_INTERVAL, 0));
+                        } catch (URISyntaxException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+        connection = futureConnection.get();
+        IoFuture<Channel> futureChannel = connection.openChannel("org.jboss.test", OptionMap.EMPTY);
+        clientChannel = futureChannel.get();
+        serverChannel = passer.getIoFuture().get();
+        assertNotNull(serverChannel);
+
+        RemoteConnectionChannel remoteClientChannel = (RemoteConnectionChannel) clientChannel;
+        assertEquals(0, Utils.getInstanceValue(remoteClientChannel.getRemoteConnection(), "heartbeatInterval"));
+        RemoteWriteListener clientWriteListener = (RemoteWriteListener) Utils
+                .getInstanceValue(remoteClientChannel.getRemoteConnection(), "writeListener");
+        assertNull(Utils.getInstanceValue(clientWriteListener, "heartKey"));
+
+        afterTest(clientChannel, serverChannel, connection, serviceRegistration);
+        destroy(endpoint, streamServer);
+    }
+
+    /**
+     * Test that heartbeat can be set and can be disabled by setting it to 0
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDefaultHeartbeat() throws Exception {
+
+        Channel clientChannel = null;
+        Channel serverChannel = null;
+
+        Closeable streamServer = null;
+        Connection connection = null;
+        Registration serviceRegistration = null;
+
+        final Endpoint endpoint = Endpoint.builder().setEndpointName("test").build();
+        NetworkServerProvider networkServerProvider = endpoint.getConnectionProviderInterface("remote",
+                NetworkServerProvider.class);
+        final SecurityDomain.Builder domainBuilder = SecurityDomain.builder();
+        final SimpleMapBackedSecurityRealm mainRealm = new SimpleMapBackedSecurityRealm();
+        domainBuilder.addRealm("mainRealm", mainRealm).build();
+        domainBuilder.setDefaultRealmName("mainRealm");
+        domainBuilder.setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.ALL);
+        final PasswordFactory passwordFactory = PasswordFactory.getInstance("clear");
+        mainRealm.setPasswordMap("bob", passwordFactory.generatePassword(new ClearPasswordSpec("pass".toCharArray())));
+        final SaslServerFactory saslServerFactory = new ServiceLoaderSaslServerFactory(
+                HeartbeatTestCase.class.getClassLoader());
+        final SaslAuthenticationFactory.Builder builder = SaslAuthenticationFactory.builder();
+        builder.setSecurityDomain(domainBuilder.build());
+        builder.setFactory(saslServerFactory);
+        builder.setMechanismConfigurationSelector(mechanismInformation -> SaslMechanismInformation.Names.SCRAM_SHA_256
+                .equals(mechanismInformation.getMechanismName()) ? MechanismConfiguration.EMPTY : null);
+        final SaslAuthenticationFactory saslAuthenticationFactory = builder.build();
+        streamServer = networkServerProvider.createServer(new InetSocketAddress("localhost", 30123),
+                OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE), saslAuthenticationFactory, SSLContext.getDefault());
+
+        final FutureResult<Channel> passer = new FutureResult<Channel>();
+        serviceRegistration = endpoint.registerService("org.jboss.test", new OpenListener() {
+            public void channelOpened(final Channel channel) {
+                passer.setResult(channel);
+            }
+
+            public void registrationTerminated() {
+            }
+        }, OptionMap.EMPTY);
+        IoFuture<Connection> futureConnection = AuthenticationContext.empty()
+                .with(MatchRule.ALL,
+                        AuthenticationConfiguration.empty().useName("bob").usePassword("pass")
+                                .setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("SCRAM-SHA-256")))
+                .run(new PrivilegedAction<IoFuture<Connection>>() {
+                    public IoFuture<Connection> run() {
+                        try {
+                            return endpoint.connect(new URI("remote://localhost:30123"),
+                                    OptionMap.EMPTY);
+                        } catch (URISyntaxException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+        connection = futureConnection.get();
+        IoFuture<Channel> futureChannel = connection.openChannel("org.jboss.test", OptionMap.EMPTY);
+        clientChannel = futureChannel.get();
+        serverChannel = passer.getIoFuture().get();
+        assertNotNull(serverChannel);
+
+        RemoteConnectionChannel remoteClientChannel = (RemoteConnectionChannel) clientChannel;
+        assertEquals(RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL, Utils.getInstanceValue(remoteClientChannel.getRemoteConnection(), "heartbeatInterval"));
+        RemoteWriteListener clientWriteListener = (RemoteWriteListener) Utils
+                .getInstanceValue(remoteClientChannel.getRemoteConnection(), "writeListener");
+        assertNotNull(Utils.getInstanceValue(clientWriteListener, "heartKey"));
+
+        afterTest(clientChannel, serverChannel, connection, serviceRegistration);
+        destroy(endpoint, streamServer);
+    }
+
+}

--- a/src/test/java/org/jboss/remoting3/test/Utils.java
+++ b/src/test/java/org/jboss/remoting3/test/Utils.java
@@ -18,6 +18,7 @@
 
 package org.jboss.remoting3.test;
 
+import java.lang.reflect.Field;
 import java.security.AllPermission;
 import java.security.PermissionCollection;
 import java.security.Permissions;
@@ -36,5 +37,17 @@ public final class Utils {
         permissions.add(new AllPermission());
         permissions.setReadOnly();
         ALL_PERMISSIONS = permissions;
+    }
+
+    public static Object getInstanceValue(final Object classInstance, final String fieldName) throws SecurityException,
+            NoSuchFieldException, ClassNotFoundException, IllegalArgumentException, IllegalAccessException {
+
+        // Get the private field
+        final Field field = classInstance.getClass().getDeclaredField(fieldName);
+        // Allow modification on the field
+        field.setAccessible(true);
+        // Return the Obect corresponding to the field
+        return field.get(classInstance);
+
     }
 }


### PR DESCRIPTION
…ed remote EJB client connections

Issue: https://issues.jboss.org/browse/REM3-331

keep_alive true, heartbeat interval to 1 minute, read/write timeout twice the heartbeat interval. The way to disable this is by using wildly-config.xml or jboss-ejb-client.properties on the client side standalone or server to server and set the numeric values to 0 and the keep_alive to false.