### PR TITLE
[REM3-332] Default heartbeat / read-timeout / write-timeout for all c…

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionBuilder.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionBuilder.java
@@ -31,13 +31,13 @@ import org.wildfly.common.Assert;
 public final class ConnectionBuilder {
     private final URI destination;
 
-    private int readTimeout = RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2; // millis
-    private int writeTimeout = RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2; // millis
-
-    private boolean tcpKeepAlive = true;
+    private int readTimeout = -1; // millis
+    private int writeTimeout = -1; // millis
+    private boolean setTcpKeepAlive;
+    private boolean tcpKeepAlive;
     private int ipTrafficClass = -1;
 
-    private int heartbeatInterval = RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL;
+    private int heartbeatInterval = -1;
 
     ConnectionBuilder(final URI destination) {
         this.destination = destination;
@@ -57,6 +57,7 @@ public final class ConnectionBuilder {
 
     public ConnectionBuilder setTcpKeepAlive(final boolean tcpKeepAlive) {
         this.tcpKeepAlive = tcpKeepAlive;
+        setTcpKeepAlive = true;
         return this;
     }
 
@@ -93,5 +94,9 @@ public final class ConnectionBuilder {
 
     int getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    boolean isSetTcpKeepAlive() {
+        return setTcpKeepAlive;
     }
 }

--- a/src/main/java/org/jboss/remoting3/EndpointBuilder.java
+++ b/src/main/java/org/jboss/remoting3/EndpointBuilder.java
@@ -29,6 +29,8 @@ import java.util.List;
 
 import org.jboss.remoting3.security.RemotingPermission;
 import org.wildfly.common.Assert;
+import org.xnio.OptionMap;
+import org.xnio.Options;
 import org.xnio.Xnio;
 import org.xnio.XnioWorker;
 
@@ -43,6 +45,11 @@ public final class EndpointBuilder {
     private List<ConnectionProviderFactoryBuilder> connectionProviderFactoryBuilders;
     private List<ConnectionBuilder> connectionBuilders;
     private XnioWorker.Builder workerBuilder;
+    //Default option map that sets heartbeat and read/write timeouts
+    private OptionMap defaultConnectionOptionMap = OptionMap.builder().set(RemotingOptions.HEARTBEAT_INTERVAL, RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL)
+            .set(Options.READ_TIMEOUT, RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2)
+            .set(Options.WRITE_TIMEOUT, RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL * 2)
+            .set(Options.KEEP_ALIVE, Boolean.TRUE).getMap();
 
     EndpointBuilder() {
     }
@@ -71,6 +78,17 @@ public final class EndpointBuilder {
         }
         connectionProviderFactoryBuilders.add(builder);
         return builder;
+    }
+
+    public EndpointBuilder setDefaultConnectionsOptionMap(OptionMap optionMap) {
+        final OptionMap.Builder optionBuilder = OptionMap.builder();
+        optionBuilder.set(RemotingOptions.HEARTBEAT_INTERVAL, optionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, defaultConnectionOptionMap.get(RemotingOptions.HEARTBEAT_INTERVAL)));
+        optionBuilder.set(Options.READ_TIMEOUT, optionMap.get(Options.READ_TIMEOUT, defaultConnectionOptionMap.get(Options.READ_TIMEOUT)));
+        optionBuilder.set(Options.WRITE_TIMEOUT, optionMap.get(Options.WRITE_TIMEOUT, defaultConnectionOptionMap.get(Options.WRITE_TIMEOUT)));
+        optionBuilder.set(Options.KEEP_ALIVE, optionMap.get(Options.KEEP_ALIVE, defaultConnectionOptionMap.get(Options.KEEP_ALIVE)));
+        defaultConnectionOptionMap = optionBuilder.getMap();
+        return this;
+
     }
 
     public ConnectionBuilder addConnection(final URI destination) {
@@ -109,6 +127,10 @@ public final class EndpointBuilder {
 
     XnioWorker.Builder getWorkerBuilder() {
         return workerBuilder;
+    }
+
+    OptionMap getDefaultConnectionOptionMap() {
+        return defaultConnectionOptionMap;
     }
 
     List<ConnectionProviderFactoryBuilder> getConnectionProviderFactoryBuilders() {

--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -112,6 +112,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
     private final ConcurrentMap<String, RegisteredServiceImpl> registeredServices = new ConcurrentHashMap<>();
     private final ConcurrentMap<ConnectionKey, ConnectionInfo> managedConnections = new ConcurrentHashMap<>();
     private final Map<URI, OptionMap> connectionOptions;
+    private final OptionMap defaultConnectionOptionMap;
 
     private final XnioWorker worker;
 
@@ -137,12 +138,13 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
     private final MBeanServer server;
     private final ObjectName objectName;
 
-    private EndpointImpl(final XnioWorker xnioWorker, final boolean ourWorker, final String name, final Map<URI, OptionMap> connectionOptions) throws NotOpenException {
+    private EndpointImpl(final XnioWorker xnioWorker, final boolean ourWorker, final String name, final Map<URI, OptionMap> connectionOptions, OptionMap defaultConnectionOptionMap) throws NotOpenException {
         super(xnioWorker, true);
         worker = xnioWorker;
         this.ourWorker = ourWorker;
         this.name = name;
         this.connectionOptions = connectionOptions;
+        this.defaultConnectionOptionMap = defaultConnectionOptionMap;
         MBeanServer server = null;
         ObjectName objectName = null;
         try {
@@ -200,20 +202,36 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
         final String endpointName = endpointBuilder.getEndpointName();
         final List<ConnectionProviderFactoryBuilder> factoryBuilders = endpointBuilder.getConnectionProviderFactoryBuilders();
         final EndpointImpl endpoint;
-
+        OptionMap defaultConnectionOptionMap = endpointBuilder.getDefaultConnectionOptionMap();
         final List<ConnectionBuilder> connectionBuilders = endpointBuilder.getConnectionBuilders();
         final Map<URI, OptionMap> connectionOptions = new HashMap<>();
         if (connectionBuilders != null) for (ConnectionBuilder connectionBuilder : connectionBuilders) {
             final URI destination = connectionBuilder.getDestination();
             final OptionMap.Builder optionBuilder = OptionMap.builder();
 
-            optionBuilder.set(RemotingOptions.HEARTBEAT_INTERVAL, connectionBuilder.getHeartbeatInterval());
-            optionBuilder.set(Options.READ_TIMEOUT, connectionBuilder.getReadTimeout());
-            optionBuilder.set(Options.WRITE_TIMEOUT, connectionBuilder.getWriteTimeout());
+            if (connectionBuilder.getHeartbeatInterval() != -1) {
+                optionBuilder.set(RemotingOptions.HEARTBEAT_INTERVAL, connectionBuilder.getHeartbeatInterval());
+            } else {
+                optionBuilder.set(RemotingOptions.HEARTBEAT_INTERVAL, defaultConnectionOptionMap.get(RemotingOptions.HEARTBEAT_INTERVAL));
+            }
+            if (connectionBuilder.getReadTimeout() != -1) {
+                optionBuilder.set(Options.READ_TIMEOUT, connectionBuilder.getReadTimeout());
+            } else {
+                optionBuilder.set(Options.READ_TIMEOUT, defaultConnectionOptionMap.get(Options.READ_TIMEOUT));
+            }
+            if (connectionBuilder.getWriteTimeout() != -1) {
+                optionBuilder.set(Options.WRITE_TIMEOUT, connectionBuilder.getWriteTimeout());
+            } else {
+                optionBuilder.set(Options.WRITE_TIMEOUT, defaultConnectionOptionMap.get(Options.WRITE_TIMEOUT));
+            }
             if (connectionBuilder.getIPTrafficClass() != -1) {
                 optionBuilder.set(Options.IP_TRAFFIC_CLASS, connectionBuilder.getIPTrafficClass());
             }
-            optionBuilder.set(Options.KEEP_ALIVE, connectionBuilder.isTcpKeepAlive());
+            if (connectionBuilder.isSetTcpKeepAlive()) {
+                optionBuilder.set(Options.KEEP_ALIVE, connectionBuilder.isTcpKeepAlive());
+            } else {
+                optionBuilder.set(Options.KEEP_ALIVE, defaultConnectionOptionMap.get(Options.KEEP_ALIVE));
+            }
             connectionOptions.put(destination, optionBuilder.getMap());
         }
 
@@ -222,7 +240,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
             final XnioWorker.Builder workerBuilder = endpointBuilder.getWorkerBuilder();
             if (workerBuilder == null) {
                 xnioWorker = XnioWorker.getContextManager().get();
-                endpoint = new EndpointImpl(xnioWorker, false, endpointName, connectionOptions);
+                endpoint = new EndpointImpl(xnioWorker, false, endpointName, connectionOptions, defaultConnectionOptionMap);
             } else {
                 final AtomicReference<EndpointImpl> endpointRef = new AtomicReference<EndpointImpl>();
                 workerBuilder.setDaemon(true);
@@ -234,10 +252,10 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
                     }
                 });
                 xnioWorker = workerBuilder.build();
-                endpointRef.set(endpoint = new EndpointImpl(xnioWorker, true, endpointName, connectionOptions.isEmpty() ? Collections.emptyMap() : connectionOptions));
+                endpointRef.set(endpoint = new EndpointImpl(xnioWorker, true, endpointName, connectionOptions.isEmpty() ? Collections.emptyMap() : connectionOptions, defaultConnectionOptionMap));
             }
         } else {
-            endpoint = new EndpointImpl(xnioWorker, false, endpointName, connectionOptions.isEmpty() ? Collections.emptyMap() : connectionOptions);
+            endpoint = new EndpointImpl(xnioWorker, false, endpointName, connectionOptions.isEmpty() ? Collections.emptyMap() : connectionOptions, defaultConnectionOptionMap);
         }
         boolean ok = false;
         try {
@@ -472,7 +490,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
         final ConnectionKey connectionKey = new ConnectionKey(realDestination, sslContext);
         ConnectionInfo newConnectionInfo = managedConnections.get(connectionKey);
         while (newConnectionInfo == null) {
-            final ConnectionInfo appearing = managedConnections.putIfAbsent(connectionKey, newConnectionInfo = new ConnectionInfo(connectionOptions.getOrDefault(realDestination, OptionMap.EMPTY)));
+            final ConnectionInfo appearing = managedConnections.putIfAbsent(connectionKey, newConnectionInfo = new ConnectionInfo(connectionOptions.getOrDefault(realDestination, defaultConnectionOptionMap)));
             if (appearing != null) {
                 newConnectionInfo = appearing;
             }
@@ -710,6 +728,16 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
 
     public XnioWorker getXnioWorker() {
         return worker;
+    }
+
+    //for testing purposes
+    OptionMap getDefaultConnectionOptionMap() {
+        return defaultConnectionOptionMap;
+    }
+
+    //for testing purposes
+    Map<URI, OptionMap> getConnectionOptions() {
+        return connectionOptions;
     }
 
     public String toString() {

--- a/src/main/java/org/jboss/remoting3/RemotingXmlParser.java
+++ b/src/main/java/org/jboss/remoting3/RemotingXmlParser.java
@@ -23,11 +23,15 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.wildfly.client.config.ClientConfiguration;
 import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.client.config.ConfigurationXMLStreamReader;
+import org.xnio.OptionMap;
+import org.xnio.Options;
 import org.xnio.XnioWorker;
 
 /**
@@ -35,6 +39,9 @@ import org.xnio.XnioWorker;
  */
 final class RemotingXmlParser {
     private static final String NS_REMOTING_5_0 = "urn:jboss-remoting:5.0";
+    private static final String NS_REMOTING_5_1 = "urn:jboss-remoting:5.1";
+
+    private static final Set<String> validNamespaces = new HashSet<>(Arrays.asList(NS_REMOTING_5_0, NS_REMOTING_5_1));
 
     private RemotingXmlParser() {
     }
@@ -43,7 +50,7 @@ final class RemotingXmlParser {
         final ClientConfiguration clientConfiguration = ClientConfiguration.getInstance();
         final EndpointBuilder builder = new EndpointBuilder();
         builder.setXnioWorker(XnioWorker.getContextManager().get());
-        if (clientConfiguration != null) try (final ConfigurationXMLStreamReader streamReader = clientConfiguration.readConfiguration(Collections.singleton(NS_REMOTING_5_0))) {
+        if (clientConfiguration != null) try (final ConfigurationXMLStreamReader streamReader = clientConfiguration.readConfiguration(validNamespaces)) {
             parseDocument(streamReader, builder);
             return builder.build();
         } else {
@@ -71,7 +78,105 @@ final class RemotingXmlParser {
     }
 
     private static void parseEndpointElement(final ConfigurationXMLStreamReader reader, final EndpointBuilder builder) throws ConfigXMLParseException {
+        if( reader.hasNamespace()) {
+            switch (reader.getNamespaceURI()) {
+                case NS_REMOTING_5_0:{
+                    parseEndpointElement50(reader, builder);
+                    break;
+                }
+                case NS_REMOTING_5_1: {
+                    parseEndpointElement51(reader, builder);
+                    break;
+                }
+                default: {
+                    throw reader.unexpectedElement();
+                }
+            }
+            while (reader.hasNext()) {
+                switch (reader.nextTag()) {
+                    case START_ELEMENT: {
+                        checkElementNamespace(reader);
+                        switch (reader.getLocalName()) {
+                            case "providers": {
+                                parseProvidersElement(reader, builder);
+                                break;
+                            }
+                            case "connections": {
+                                parseConnectionsElement(reader, builder);
+                                break;
+                            }
+                            default: throw reader.unexpectedElement();
+                        }
+                        break;
+                    }
+                    case END_ELEMENT: {
+                        return;
+                    }
+                }
+            }
+            throw reader.unexpectedDocumentEnd();
+        } else {
+            throw reader.unexpectedDocumentEnd();
+        }
+    }
+
+    private static void parseEndpointElement51(final ConfigurationXMLStreamReader reader, final EndpointBuilder builder) throws ConfigXMLParseException {
         final int attributeCount = reader.getAttributeCount();
+        int readTimeout = -1;
+        int writeTimeout = -1;
+        boolean tcpKeepAlive = false;
+        boolean setTcpKeepAlive = false;
+        int heartbeatInterval = -1;
+        for (int i = 0; i < attributeCount; i++) {
+            checkAttributeNamespace(reader, i);
+            switch (reader.getAttributeLocalName(i)) {
+                case "name": {
+                    builder.setEndpointName(reader.getAttributeValueResolved(i));
+                    break;
+                }
+                case "read-timeout": {
+                    readTimeout = reader.getIntAttributeValueResolved(i, 0, Integer.MAX_VALUE);
+                    break;
+                }
+                case "write-timeout": {
+                    writeTimeout = reader.getIntAttributeValueResolved(i, 0, Integer.MAX_VALUE);
+                    break;
+                }
+                case "tcp-keepalive": {
+                    setTcpKeepAlive = true;
+                    tcpKeepAlive = reader.getBooleanAttributeValueResolved(i);
+                    break;
+                }
+                case "heartbeat-interval": {
+                    heartbeatInterval = reader.getIntAttributeValueResolved(i, 0, Integer.MAX_VALUE);
+                    break;
+                }
+                default: {
+                    throw reader.unexpectedAttribute(i);
+                }
+            }
+        }
+        OptionMap.Builder optionMapBuilder = OptionMap.builder();
+        if (readTimeout != -1L) {
+            optionMapBuilder.set(Options.READ_TIMEOUT, readTimeout);
+        }
+        if (writeTimeout != -1L) {
+            optionMapBuilder.set(Options.WRITE_TIMEOUT, writeTimeout);
+        }
+        if (setTcpKeepAlive) {
+            optionMapBuilder.set(Options.KEEP_ALIVE, tcpKeepAlive);
+        }
+        if (heartbeatInterval != -1) {
+            optionMapBuilder.set(RemotingOptions.HEARTBEAT_INTERVAL, heartbeatInterval);
+        }
+
+        builder.setDefaultConnectionsOptionMap(optionMapBuilder.getMap());
+    }
+
+
+    private static void parseEndpointElement50(final ConfigurationXMLStreamReader reader, final EndpointBuilder builder) throws ConfigXMLParseException {
+        final int attributeCount = reader.getAttributeCount();
+
         for (int i = 0; i < attributeCount; i++) {
             checkAttributeNamespace(reader, i);
             switch (reader.getAttributeLocalName(i)) {
@@ -84,29 +189,6 @@ final class RemotingXmlParser {
                 }
             }
         }
-        while (reader.hasNext()) {
-            switch (reader.nextTag()) {
-                case START_ELEMENT: {
-                    checkElementNamespace(reader);
-                    switch (reader.getLocalName()) {
-                        case "providers": {
-                            parseProvidersElement(reader, builder);
-                            break;
-                        }
-                        case "connections": {
-                            parseConnectionsElement(reader, builder);
-                            break;
-                        }
-                        default: throw reader.unexpectedElement();
-                    }
-                    break;
-                }
-                case END_ELEMENT: {
-                    return;
-                }
-            }
-        }
-        throw reader.unexpectedDocumentEnd();
     }
 
     private static void parseProvidersElement(final ConfigurationXMLStreamReader reader, final EndpointBuilder builder) throws ConfigXMLParseException {
@@ -292,7 +374,8 @@ final class RemotingXmlParser {
 
     private static void checkElementNamespace(final ConfigurationXMLStreamReader reader) throws ConfigXMLParseException {
         switch (reader.getNamespaceURI()) {
-            case NS_REMOTING_5_0: break;
+            case NS_REMOTING_5_0:
+            case NS_REMOTING_5_1: break;
             default: throw reader.unexpectedElement();
         }
     }

--- a/src/main/resources/schema/jboss-remoting_5_1.xsd
+++ b/src/main/resources/schema/jboss-remoting_5_1.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2017 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss-remoting:5.1"
+            xmlns="urn:jboss-remoting:5.1"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <xs:element name="endpoint" type="endpoint-type"/>
+
+    <xs:complexType name="endpoint-type">
+        <xs:all minOccurs="0" maxOccurs="1">
+            <xs:element name="providers" type="providers-type" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="connections" type="connections-type" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="optional" type="xs:string"/>
+        <xs:attribute name="read-timeout" use="optional" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="write-timeout" use="optional" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="tcp-keepalive" use="optional" type="xs:boolean"/>
+        <xs:attribute name="heartbeat-interval" use="optional" type="xs:nonNegativeInteger"/>
+    </xs:complexType>
+
+    <xs:complexType name="providers-type">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="provider" type="provider-type"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="provider-type">
+        <xs:attribute name="scheme" use="required" type="xs:string"/>
+        <xs:attribute name="aliases" use="optional" type="string-list-type"/>
+        <xs:attribute name="module" use="optional" type="xs:string"/>
+        <xs:attribute name="class" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="connections-type">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="connection" type="connection-type"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="connection-type">
+        <xs:attribute name="destination" use="required" type="xs:anyURI"/>
+        <xs:attribute name="read-timeout" use="optional" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="write-timeout" use="optional" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="ip-traffic-class" use="optional" type="xs:nonNegativeInteger"/>
+        <xs:attribute name="tcp-keepalive" use="optional" type="xs:boolean"/>
+        <xs:attribute name="heartbeat-interval" use="optional" type="xs:nonNegativeInteger"/>
+    </xs:complexType>
+
+    <xs:simpleType name="string-list-type">
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+</xs:schema>

--- a/src/test/java/org/jboss/remoting3/RemotingXmlParserTestCase.java
+++ b/src/test/java/org/jboss/remoting3/RemotingXmlParserTestCase.java
@@ -1,0 +1,184 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.remoting3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.security.Security;
+import java.util.Map;
+
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.wildfly.client.config.ConfigXMLParseException;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+
+public class RemotingXmlParserTestCase {
+
+    protected static Endpoint endpoint;
+
+    @Rule
+    public TestName name = new TestName();
+
+    private static String providerName;
+
+    @BeforeClass
+    public static void doBeforeClass() {
+        final WildFlyElytronProvider provider = new WildFlyElytronProvider();
+        Security.addProvider(provider);
+        providerName = provider.getName();
+    }
+
+    @AfterClass
+    public static void doAfterClass() {
+        Security.removeProvider(providerName);
+    }
+
+    @Before
+    public void doBefore() {
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Running test %s", name.getMethodName());
+    }
+
+    @After
+    public void doAfter() {
+        clearResources();
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Finished test %s", name.getMethodName());
+    }
+
+    /**
+     * Tests that setting some values works.
+     * @throws Exception
+     */
+    @Test
+    public void getEndpointAttributesTest() throws Exception {
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("wildfly-config-endpoint.xml").getFile());
+        System.setProperty("wildfly.config.url", file.getAbsolutePath());
+        // create endpoint
+        Endpoint endpoint = RemotingXmlParser.parseEndpoint();
+        OptionMap optionMap = ((EndpointImpl)endpoint).getDefaultConnectionOptionMap();
+
+        assertEquals("Wrong value for readtimeout", 1000, optionMap.get(Options.READ_TIMEOUT, 0));
+        assertEquals("Wrong value for writetimeout", 1000, optionMap.get(Options.WRITE_TIMEOUT, 0));
+        assertEquals("Wrong value for heartbeat", 500, optionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, 0));
+        assertEquals("Wrong value for keep_alive", true, optionMap.get(Options.KEEP_ALIVE, false));
+    }
+
+    /**
+     * Tests that uses the default values.
+     * @throws Exception
+     */
+    @Test
+    public void defaultValuesTest() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("wildfly-config-connection.xml").getFile());
+        System.setProperty("wildfly.config.url", file.getAbsolutePath());
+        // create endpoint
+        Endpoint endpoint = RemotingXmlParser.parseEndpoint();
+        OptionMap optionMap = ((EndpointImpl)endpoint).getDefaultConnectionOptionMap();
+
+        assertEquals("Wrong value for readtimeout", 120000, optionMap.get(Options.READ_TIMEOUT, 0));
+        assertEquals("Wrong value for writetimeout", 120000, optionMap.get(Options.WRITE_TIMEOUT, 0));
+        assertEquals("Wrong value for heartbeat", 60000, optionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, 0));
+        assertEquals("Wrong value for keep_alive", true, optionMap.get(Options.KEEP_ALIVE, false));
+
+        Map<URI, OptionMap> connectionOptions = ((EndpointImpl)endpoint).getConnectionOptions();
+
+        OptionMap connectionOptionMap = connectionOptions.values().iterator().next();
+        //check if values are merged
+        assertEquals("Wrong value for readtimeout", 11000, connectionOptionMap.get(Options.READ_TIMEOUT, 0));
+        assertEquals("Wrong value for writetimeout", 11000, connectionOptionMap.get(Options.WRITE_TIMEOUT, 0));
+        assertEquals("Wrong value for heartbeat", 60000, connectionOptionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, 0));
+        assertEquals("Wrong value for keep_alive", true, connectionOptionMap.get(Options.KEEP_ALIVE, false));
+
+    }
+
+    /**
+     * Tests that setting some values works from 51 does not work.
+     * @throws Exception
+     */
+    @Test
+    public void parse50ErrorTest() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("wildfly-config-50.xml").getFile());
+        System.setProperty("wildfly.config.url", file.getAbsolutePath());
+        boolean isConfigurationException = false;
+        // create endpoint
+        try {
+            endpoint = RemotingXmlParser.parseEndpoint();
+        } catch (Exception e) {
+            if(e instanceof ConfigXMLParseException) {
+                isConfigurationException = true;
+            }
+        }
+        assertTrue("No configuration exception", isConfigurationException );
+    }
+
+    /**
+     * Tests that parsing 50 connections works.
+     * @throws Exception
+     */
+    @Test
+    public void parse50Test() throws Exception {
+
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("wildfly-config-connection-50.xml").getFile());
+        System.setProperty("wildfly.config.url", file.getAbsolutePath());
+        // create endpoint
+        Endpoint endpoint = RemotingXmlParser.parseEndpoint();
+        Map<URI, OptionMap> connectionOptions = ((EndpointImpl)endpoint).getConnectionOptions();
+
+        OptionMap connectionOptionMap = connectionOptions.values().iterator().next();
+        //check if values are merged
+        assertEquals("Wrong value for readtimeout", 11000, connectionOptionMap.get(Options.READ_TIMEOUT, 0));
+        assertEquals("Wrong value for writetimeout", 11000, connectionOptionMap.get(Options.WRITE_TIMEOUT, 0));
+        assertEquals("Wrong value for heartbeat", 60000, connectionOptionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, 0));
+        assertEquals("Wrong value for keep_alive", true, connectionOptionMap.get(Options.KEEP_ALIVE, false));
+
+    }
+
+    private void clearResources() {
+        if (endpoint != null) {
+            try {
+                endpoint.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            endpoint = null;
+        }
+        System.clearProperty("wildfly.config.url");
+    }
+
+}

--- a/src/test/resources/wildfly-config-50.xml
+++ b/src/test/resources/wildfly-config-50.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <endpoint xmlns="urn:jboss-remoting:5.0" heartbeat-interval="500" read-timeout="1000" write-timeout="1000" tcp-keepalive="true" />
+</configuration>

--- a/src/test/resources/wildfly-config-connection-50.xml
+++ b/src/test/resources/wildfly-config-connection-50.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <endpoint xmlns="urn:jboss-remoting:5.0" >
+        <connections>
+            <connection destination="remote+http://localhost:8080" read-timeout="11000" write-timeout="11000" />
+        </connections>
+    </endpoint>
+</configuration>

--- a/src/test/resources/wildfly-config-connection.xml
+++ b/src/test/resources/wildfly-config-connection.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <endpoint xmlns="urn:jboss-remoting:5.1" >
+        <connections>
+            <connection destination="remote+http://localhost:8080" read-timeout="11000" write-timeout="11000" />
+        </connections>
+    </endpoint>
+</configuration>

--- a/src/test/resources/wildfly-config-endpoint.xml
+++ b/src/test/resources/wildfly-config-endpoint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <endpoint xmlns="urn:jboss-remoting:5.1" heartbeat-interval="500" read-timeout="1000" write-timeout="1000" tcp-keepalive="true" />
+</configuration>


### PR DESCRIPTION
…onnections in wildfly-config.xml

It adds default values at endpoint level that can be overridden at connection level.

Issue: https://issues.jboss.org/browse/REM3-332