### PR TITLE
[REM3-337] At ConnectionInfo.None state, method getConnection, update…

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionInfo.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionInfo.java
@@ -83,6 +83,7 @@ final class ConnectionInfo {
                     final MaybeShared maybeShared = new MaybeShared(authenticationConfiguration, attempt);
                     final FutureResult<Connection> futureResult = new FutureResult<>();
                     splice(futureResult, attempt, authenticationConfiguration);
+                    state = maybeShared;
                     attempt.addNotifier(new IoFuture.HandlingNotifier<Connection, Void>() {
                         public void handleCancelled(final Void attachment) {
                             final ConnectionInfo outer = ConnectionInfo.this;
@@ -140,7 +141,6 @@ final class ConnectionInfo {
                         }
 
                     }, null);
-                    state = maybeShared;
                     return futureResult.getIoFuture();
                 }
             }


### PR DESCRIPTION
… the state before adding a notifier, or else the state might be overwritten to MaybeShared after notifier has run.

In other words, the failure to reatempt connection happens when:
-> ConnectionInfo.None.getConnection adds the notifier
-> the notifier is invoked synchronously, handleFailed executes to indicate the connection is not there and sets the state to None
-> and getConnection mistakenly overwrites state to MaybeShared after notifier has run
-> on a second attempt to connect, MaybeShared.getConnection is invoked instead of None.getConnection, resulting in a non executed pending attempt to connect

Jira: https://issues.jboss.org/browse/REM3-337