### PR TITLE
[REM3-329] - Unable to parse endpoint XML definition if more than one…

### DIFF
--- a/src/test/java/org/jboss/remoting3/RemotingXmlParserTestCase.java
+++ b/src/test/java/org/jboss/remoting3/RemotingXmlParserTestCase.java
@@ -77,6 +77,18 @@ public class RemotingXmlParserTestCase {
     }
 
     /**
+     * Test parse configuration with more connections
+     * @throws Exception
+     */
+    @Test
+    public void parseMoreConnections() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        File file = new File(classLoader.getResource("wildfly-config-more-connection.xml").getFile());
+        System.setProperty("wildfly.config.url", file.getAbsolutePath());
+        RemotingXmlParser.parseEndpoint();
+    }
+
+    /**
      * Tests that setting some values works.
      * @throws Exception
      */

--- a/src/test/resources/wildfly-config-more-connection.xml
+++ b/src/test/resources/wildfly-config-more-connection.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <endpoint xmlns="urn:jboss-remoting:5.0">
+        <connections>
+            <connection destination="remote+http://localhost:8080" read-timeout="20000" write-timeout="20000" heartbeat-interval="10000"/>
+            <connection destination="remote+http://localhost:8380" read-timeout="20000" write-timeout="20000" heartbeat-interval="10000"/>
+        </connections>
+    </endpoint>
+</configuration>


### PR DESCRIPTION
Jira [https://issues.jboss.org/browse/REM3-329](https://issues.jboss.org/browse/REM3-329)

Description:
A client side wildfly-config.xml file with the following endpoint configuration:

fails with a ConfigXMLParseException and logs: