### PR TITLE
[REM3-338] At RemoteConnection.send, calculate expire time only if we…

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
@@ -362,7 +362,9 @@ final class RemoteConnection {
         public void send(final Pooled<ByteBuffer> pooled, final boolean close) {
             connection.getIoThread().execute(() -> {
                 synchronized (queue) {
-                    this.expireTime = System.currentTimeMillis() + heartbeatInterval;
+                    XnioExecutor.Key heartKey1 = heartKey;
+                    if (heartKey1 != null)
+                        this.expireTime = System.currentTimeMillis() + heartbeatInterval;
                     if (closed) { pooled.free(); return; }
                     if (close) { closed = true; }
                     boolean free = true;


### PR DESCRIPTION
… have a scheduled task, thus saving the extra cost of calculating it when keep alive is disabled

Jira: https://issues.jboss.org/browse/REM3-338