### PR TITLE
[REM3-344] Clean up authMap entries in exception/error cases where they are not …

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionPeerIdentityContext.java
@@ -218,6 +218,7 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
         boolean intr = Thread.currentThread().isInterrupted();
         if (intr) {
             futureResult.setException(log.authenticationInterrupted());
+            authMap.remove(authentication);
             futureAuths.remove(configuration, futureResult.getIoFuture());
             return;
         }
@@ -234,6 +235,7 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
                     saslClient = client.createSaslClient(connection.getPeerURI(), configuration, mechanisms, factoryOperator, sslSession);
                 } catch (SaslException e) {
                     futureResult.setException(log.authenticationNoSaslClient(e));
+                    authMap.remove(authentication);
                     futureAuths.remove(configuration, futureResult.getIoFuture());
                     return;
                 }
@@ -375,6 +377,7 @@ public final class ConnectionPeerIdentityContext extends PeerIdentityContext {
                 triedStr = "(none)";
             }
             futureResult.setException(log.noAuthMechanismsLeft(triedStr));
+            authMap.remove(authentication);
             futureAuths.remove(configuration, futureResult.getIoFuture());
             return;
         } finally {


### PR DESCRIPTION
There are a few exception/error cases where the authentication object in authMap isn't cleaned up.