### PR TITLE
[REM3-349] Update ServerConnectionOpenListener and ConnectionImpl to inform the callback handler of the local socket address and the peer socket address

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionImpl.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionImpl.java
@@ -41,6 +41,7 @@ import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.ProtocolSaslServerFactory;
 import org.wildfly.security.sasl.util.SSLSaslServerFactory;
 import org.wildfly.security.sasl.util.ServerNameSaslServerFactory;
+import org.wildfly.security.sasl.util.SocketAddressCallbackSaslServerFactory;
 import org.xnio.FutureResult;
 import org.xnio.IoFuture;
 import org.xnio.OptionMap;
@@ -194,7 +195,7 @@ class ConnectionImpl extends AbstractHandleableCloseable<Connection> implements 
             final SSLSession sslSession = connectionHandler.getSslSession();
             try {
                 saslServer = authenticationFactory.createMechanism(mechName, f ->
-                    new ServerNameSaslServerFactory(new ProtocolSaslServerFactory(sslSession != null ? new SSLSaslServerFactory(f, connectionHandler::getSslSession) : f, saslProtocol), connectionHandler.getLocalSaslServerName())
+                    new ServerNameSaslServerFactory(new ProtocolSaslServerFactory(new SocketAddressCallbackSaslServerFactory(sslSession != null ? new SSLSaslServerFactory(f, connectionHandler::getSslSession) : f, getLocalAddress(), getPeerAddress()), saslProtocol), connectionHandler.getLocalSaslServerName())
                 );
             } catch (SaslException e) {
                 log.trace("Authentication failed at mechanism creation", e);

--- a/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
@@ -50,6 +50,7 @@ import org.wildfly.security.sasl.util.PropertiesSaslServerFactory;
 import org.wildfly.security.sasl.util.ProtocolSaslServerFactory;
 import org.wildfly.security.sasl.util.SSLSaslServerFactory;
 import org.wildfly.security.sasl.util.ServerNameSaslServerFactory;
+import org.wildfly.security.sasl.util.SocketAddressCallbackSaslServerFactory;
 import org.wildfly.security.ssl.SSLUtils;
 import org.xnio.Buffers;
 import org.xnio.ChannelListener;
@@ -279,6 +280,7 @@ final class ServerConnectionOpenListener  implements ChannelListener<ConduitStre
                         SaslServer saslServer;
                         try {
                             saslServer = saslAuthenticationFactory.createMechanism(mechName, saslServerFactory -> {
+                                saslServerFactory = new SocketAddressCallbackSaslServerFactory(saslServerFactory, connection.getLocalAddress(), connection.getPeerAddress());
                                 saslServerFactory = sslSession != null ? new SSLSaslServerFactory(saslServerFactory, () -> sslSession) : saslServerFactory;
                                 saslServerFactory = new ServerNameSaslServerFactory(saslServerFactory, serverName);
                                 saslServerFactory = new ProtocolSaslServerFactory(saslServerFactory, protocol);


### PR DESCRIPTION
https://issues.jboss.org/browse/REM3-349

This is needed in order to add the ability to make use of the IP address of a remote client when making authorization decisions (see https://github.com/wildfly/wildfly-proposals/pull/254).