### PR TITLE
[REM3-352] At ConnectionInfo$NotShared.getConnection, update the stat…

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionInfo.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionInfo.java
@@ -276,6 +276,7 @@ final class ConnectionInfo {
                     final FutureResult<Connection> futureResult = new FutureResult<>();
                     splice(futureResult, attempt, authenticationConfiguration);
                     newConnections.put(authenticationConfiguration, futureResult);
+                    state = new NotShared(newConnections);
                     return attempt;
                 }
             }


### PR DESCRIPTION
…e with a new not shared state so that connections map is updated.

Jira: https://issues.redhat.com/browse/REM3-352
Master PR: https://github.com/jboss-remoting/jboss-remoting/pull/229