### PR TITLE
[REM3-375] Allow services to be registered with a validation predicate

### DIFF
--- a/src/main/java/org/jboss/remoting3/Endpoint.java
+++ b/src/main/java/org/jboss/remoting3/Endpoint.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedAction;
+import java.util.function.Predicate;
 
 import org.jboss.remoting3._private.Messages;
 import org.jboss.remoting3.security.RemotingPermission;
@@ -97,6 +98,18 @@ public interface Endpoint extends HandleableCloseable<Endpoint>, Attachable, Con
      * @throws ServiceRegistrationException if the service could not be registered
      */
     Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap) throws ServiceRegistrationException;
+
+    /**
+     * Register a new service.
+     *
+     * @param serviceType the service type
+     * @param openListener the channel open listener
+     * @param optionMap the option map
+     * @param validationPredicate the validation predicate to apply
+     * @return the service registration which may be closed to remove the service
+     * @throws ServiceRegistrationException if the service could not be registered
+     */
+    Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap, Predicate<Connection> validationPredicate) throws ServiceRegistrationException;
 
     /**
      * Get a possibly shared, possibly existing connection to the destination.  The authentication and SSL configuration is selected from

--- a/src/main/java/org/jboss/remoting3/UncloseableEndpoint.java
+++ b/src/main/java/org/jboss/remoting3/UncloseableEndpoint.java
@@ -21,6 +21,7 @@ package org.jboss.remoting3;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 
@@ -45,6 +46,10 @@ final class UncloseableEndpoint implements Endpoint {
 
     public Registration registerService(final String serviceType, final OpenListener openListener, final OptionMap optionMap) throws ServiceRegistrationException {
         return endpoint.registerService(serviceType, openListener, optionMap);
+    }
+
+    public Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap, Predicate<Connection> validationPredicate) throws ServiceRegistrationException {
+        return endpoint.registerService(serviceType, openListener, optionMap, validationPredicate);
     }
 
     public IoFuture<ConnectionPeerIdentity> getConnectedIdentity(final URI destination, final SSLContext sslContext, final AuthenticationConfiguration authenticationConfiguration) {

--- a/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
@@ -187,6 +187,10 @@ final class RemoteReadListener implements ChannelListener<ConduitStreamSourceCha
                                 refuseService(channelId, "Unknown service name " + serviceType);
                                 break;
                             }
+                            if (! registeredService.validateService(handler.getConnectionContext().getConnection())) {
+                                refuseService(channelId, "Service refused");
+                                break;
+                            }
                             final OptionMap serviceOptionMap = registeredService.getOptionMap();
 
                             final int outboundWindowOptionValue = serviceOptionMap.get(RemotingOptions.TRANSMIT_WINDOW_SIZE, RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE);

--- a/src/main/java/org/jboss/remoting3/spi/RegisteredService.java
+++ b/src/main/java/org/jboss/remoting3/spi/RegisteredService.java
@@ -18,6 +18,7 @@
 
 package org.jboss.remoting3.spi;
 
+import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.OpenListener;
 import org.xnio.OptionMap;
 
@@ -41,4 +42,14 @@ public interface RegisteredService {
      * @return the service option map
      */
     OptionMap getOptionMap();
+
+    /**
+     * Validate the service for the given connection.
+     *
+     * @param connection the connection (must not be {@code null})
+     * @return {@code true} if the service is allowed, {@code false} otherwise
+     */
+    default boolean validateService(Connection connection) {
+        return true;
+    }
 }


### PR DESCRIPTION
This will allow (for example) EJB service requests to be refused if the connection is not one of the registered connectors for that service.

/cc @rachmatowicz 