### PR TITLE
[REM3-375] Allow services to be registered with a validation predicate

### DIFF
--- a/src/main/java/org/jboss/remoting3/Endpoint.java
+++ b/src/main/java/org/jboss/remoting3/Endpoint.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedAction;
+import java.util.function.Predicate;
 
 import org.jboss.remoting3._private.Messages;
 import org.jboss.remoting3.security.RemotingPermission;
@@ -98,6 +99,18 @@ public interface Endpoint extends HandleableCloseable<Endpoint>, Attachable, Con
      * @throws ServiceRegistrationException if the service could not be registered
      */
     Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap) throws ServiceRegistrationException;
+
+    /**
+     * Register a new service.
+     *
+     * @param serviceType the service type
+     * @param openListener the channel open listener
+     * @param optionMap the option map
+     * @param validationPredicate the validation predicate to apply
+     * @return the service registration which may be closed to remove the service
+     * @throws ServiceRegistrationException if the service could not be registered
+     */
+    Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap, Predicate<Connection> validationPredicate) throws ServiceRegistrationException;
 
     /**
      * Get a possibly shared, possibly existing connection to the destination.  The authentication and SSL configuration is selected from

--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 
@@ -415,6 +416,15 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
     }
 
     public Registration registerService(final String serviceType, final OpenListener openListener, final OptionMap optionMap) throws ServiceRegistrationException {
+        return registerService(serviceType, openListener, optionMap, EndpointImpl::alwaysTrue);
+    }
+
+    private static boolean alwaysTrue(Connection ignored) {
+        return true;
+    }
+
+    public Registration registerService(final String serviceType, final OpenListener openListener, final OptionMap optionMap, final Predicate<Connection> validationPredicate) throws ServiceRegistrationException {
+        Assert.checkNotNullParam("validationPredicate", validationPredicate);
         if (! VALID_SERVICE_PATTERN.matcher(serviceType).matches()) {
             throw new IllegalArgumentException("Service type must match " + VALID_SERVICE_PATTERN);
         }
@@ -422,7 +432,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
         if (sm != null) {
             sm.checkPermission(RemotingPermission.REGISTER_SERVICE);
         }
-        final RegisteredServiceImpl registeredService = new RegisteredServiceImpl(openListener, optionMap);
+        final RegisteredServiceImpl registeredService = new RegisteredServiceImpl(openListener, optionMap, validationPredicate);
         if (registeredServices.putIfAbsent(serviceType, registeredService) != null) {
             throw new ServiceRegistrationException("Service type '" + serviceType + "' is already registered");
         }
@@ -960,10 +970,12 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
     static class RegisteredServiceImpl implements RegisteredService {
         private final OpenListener openListener;
         private final OptionMap optionMap;
+        private final Predicate<Connection> predicate;
 
-        private RegisteredServiceImpl(final OpenListener openListener, final OptionMap optionMap) {
+        RegisteredServiceImpl(final OpenListener openListener, final OptionMap optionMap, final Predicate<Connection> predicate) {
             this.openListener = openListener;
             this.optionMap = optionMap;
+            this.predicate = predicate;
         }
 
         public OpenListener getOpenListener() {
@@ -972,6 +984,10 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
 
         public OptionMap getOptionMap() {
             return optionMap;
+        }
+
+        public boolean validateService(final Connection connection) {
+            return predicate.test(connection);
         }
     }
 

--- a/src/main/java/org/jboss/remoting3/LegacyEndpoint.java
+++ b/src/main/java/org/jboss/remoting3/LegacyEndpoint.java
@@ -25,6 +25,7 @@ package org.jboss.remoting3;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
@@ -103,6 +104,11 @@ public class LegacyEndpoint implements Endpoint {
 	public Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap)
 			throws ServiceRegistrationException {
 		return this.endpoint.registerService(serviceType, openListener, optionMap);
+	}
+	@Override
+	public Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap, Predicate<Connection> validationPredicate)
+			throws ServiceRegistrationException {
+		return this.endpoint.registerService(serviceType, openListener, optionMap, validationPredicate);
 	}
 
 	@Override

--- a/src/main/java/org/jboss/remoting3/UncloseableEndpoint.java
+++ b/src/main/java/org/jboss/remoting3/UncloseableEndpoint.java
@@ -21,6 +21,7 @@ package org.jboss.remoting3;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.function.Predicate;
 
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
@@ -46,6 +47,10 @@ final class UncloseableEndpoint implements Endpoint {
 
     public Registration registerService(final String serviceType, final OpenListener openListener, final OptionMap optionMap) throws ServiceRegistrationException {
         return endpoint.registerService(serviceType, openListener, optionMap);
+    }
+
+    public Registration registerService(String serviceType, OpenListener openListener, OptionMap optionMap, Predicate validationPredicate) throws ServiceRegistrationException {
+        return endpoint.registerService(serviceType, openListener, optionMap, validationPredicate);
     }
 
     public IoFuture<ConnectionPeerIdentity> getConnectedIdentity(final URI destination, final SSLContext sslContext, final AuthenticationConfiguration authenticationConfiguration) {

--- a/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
@@ -187,6 +187,10 @@ final class RemoteReadListener implements ChannelListener<ConduitStreamSourceCha
                                 refuseService(channelId, "Unknown service name " + serviceType);
                                 break;
                             }
+                            if (! registeredService.validateService(handler.getConnectionContext().getConnection())) {
+                                refuseService(channelId, "Service refused");
+                                break;
+                            }
                             final OptionMap serviceOptionMap = registeredService.getOptionMap();
 
                             final int outboundWindowOptionValue = serviceOptionMap.get(RemotingOptions.TRANSMIT_WINDOW_SIZE, RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE);

--- a/src/main/java/org/jboss/remoting3/spi/RegisteredService.java
+++ b/src/main/java/org/jboss/remoting3/spi/RegisteredService.java
@@ -18,6 +18,7 @@
 
 package org.jboss.remoting3.spi;
 
+import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.OpenListener;
 import org.xnio.OptionMap;
 
@@ -41,4 +42,14 @@ public interface RegisteredService {
      * @return the service option map
      */
     OptionMap getOptionMap();
+
+    /**
+     * Validate the service for the given connection.
+     *
+     * @param connection the connection (must not be {@code null})
+     * @return {@code true} if the service is allowed, {@code false} otherwise
+     */
+    default boolean validateService(Connection connection) {
+        return true;
+    }
 }

--- a/src/test/java/org/jboss/remoting3/test/RemoteServiceWithPredicateTest.java
+++ b/src/test/java/org/jboss/remoting3/test/RemoteServiceWithPredicateTest.java
@@ -1,0 +1,228 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.remoting3.test;
+
+import org.jboss.logging.Logger;
+import org.jboss.remoting3.Channel;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.OpenListener;
+import org.jboss.remoting3.Registration;
+import org.jboss.remoting3.spi.NetworkServerProvider;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.wildfly.security.WildFlyElytronProvider;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
+import org.wildfly.security.auth.server.MechanismConfiguration;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SecurityDomain;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.permission.PermissionVerifier;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+import org.wildfly.security.sasl.util.SaslMechanismInformation;
+import org.wildfly.security.sasl.util.ServiceLoaderSaslServerFactory;
+import org.xnio.FutureResult;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+
+import javax.net.ssl.SSLContext;
+import javax.security.sasl.SaslServerFactory;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.PrivilegedAction;
+import java.security.Security;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.xnio.IoUtils.safeClose;
+
+/**
+ * Test for creation of channels for services which have validationPredicates specified.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
+ */
+public final class RemoteServiceWithPredicateTest  {
+    protected static Endpoint endpoint;
+    private static Closeable streamServer;
+    private static String providerName ;
+
+    /**
+     * Create an Endpoint and an AcceptingChannel<StreamConnection> to receive connection requests
+     * @throws Exception
+     */
+    @BeforeClass
+    public static void create() throws Exception {
+        final WildFlyElytronProvider provider = new WildFlyElytronProvider();
+        Security.addProvider(provider);
+        providerName = provider.getName();
+
+        endpoint = Endpoint.builder().setEndpointName("test").build();
+        NetworkServerProvider networkServerProvider = endpoint.getConnectionProviderInterface("remote", NetworkServerProvider.class);
+        final SecurityDomain.Builder domainBuilder = SecurityDomain.builder();
+        final SimpleMapBackedSecurityRealm mainRealm = new SimpleMapBackedSecurityRealm();
+        domainBuilder.addRealm("mainRealm", mainRealm).build();
+        domainBuilder.setDefaultRealmName("mainRealm");
+        domainBuilder.setPermissionMapper((permissionMappable, roles) -> PermissionVerifier.ALL);
+        final PasswordFactory passwordFactory = PasswordFactory.getInstance("clear");
+        mainRealm.setPasswordMap("bob", passwordFactory.generatePassword(new ClearPasswordSpec("pass".toCharArray())));
+        final SaslServerFactory saslServerFactory = new ServiceLoaderSaslServerFactory(RemoteServiceWithPredicateTest.class.getClassLoader());
+        final SaslAuthenticationFactory.Builder builder = SaslAuthenticationFactory.builder();
+        builder.setSecurityDomain(domainBuilder.build());
+        builder.setFactory(saslServerFactory);
+        builder.setMechanismConfigurationSelector(mechanismInformation -> SaslMechanismInformation.Names.SCRAM_SHA_256.equals(mechanismInformation.getMechanismName()) ? MechanismConfiguration.EMPTY : null);
+        final SaslAuthenticationFactory saslAuthenticationFactory = builder.build();
+        streamServer = networkServerProvider.createServer(new InetSocketAddress("localhost", 30123), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE), saslAuthenticationFactory, SSLContext.getDefault());
+    }
+
+    @AfterClass
+    public static void destroy() throws IOException, InterruptedException {
+        safeClose(streamServer);
+        safeClose(endpoint);
+        Security.removeProvider(providerName);
+    }
+
+    @Rule
+    public TestName name = new TestName();
+
+    @Before
+    public void doBefore() {
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Running test %s", name.getMethodName());
+    }
+
+    @After
+    public void doAfter() {
+        System.gc();
+        System.runFinalization();
+        Logger.getLogger("TEST").infof("Finished test %s", name.getMethodName());
+    }
+
+    /**
+     * Test which verifies that a validationPredicate evaluating to true will accept creation of service Channels
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testAcceptedByPredicate() throws IOException {
+        // the validation predicate
+        final Predicate<Connection> validationPredicate = connection -> true;
+        tryToConnectToService(validationPredicate, true);
+    }
+
+    /**
+     * Test which verifies that a validationPredicate evaluating to false will prohibit creation of service Channels
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testRefusedByPredicate() throws IOException {
+        // the validation predicate
+        final Predicate<Connection> validationPredicate = connection -> false;
+        tryToConnectToService(validationPredicate, false);
+    }
+
+    /**
+     * Method which registers a service with the provided validationPredicate, then tests to see if the service
+     * accepts or rejects service Channel creation attempts which are expected by the predicate provided.
+     *
+     * @param validationPredicate
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws InterruptedException
+     */
+    public void tryToConnectToService(Predicate<Connection> validationPredicate, boolean shouldSucceed) throws IOException {
+        Connection connection;
+        Registration serviceRegistration;
+        Channel sendChannel = null, recvChannel = null;
+        final FutureResult<Channel> passer = new FutureResult<Channel>();
+
+        // register the service with the endpoint using the provided validationPredicate
+        serviceRegistration = endpoint.registerService("org.jboss.test", new OpenListener() {
+            public void channelOpened(final Channel channel) {
+                passer.setResult(channel);
+            }
+
+            public void registrationTerminated() {
+            }
+        }, OptionMap.EMPTY, validationPredicate);
+
+        // create a connection to the endpoint's connector
+        IoFuture<Connection> futureConnection = AuthenticationContext.empty().with(MatchRule.ALL, AuthenticationConfiguration.empty().useName("bob").usePassword("pass").setSaslMechanismSelector(SaslMechanismSelector.NONE.addMechanism("SCRAM-SHA-256"))).run(new PrivilegedAction<IoFuture<Connection>>() {
+            public IoFuture<Connection> run() {
+                try {
+                    return endpoint.connect(new URI("remote://localhost:30123"), OptionMap.EMPTY);
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        connection = futureConnection.get();
+        assertNull("No SSLSession", connection.getSslSession());
+
+        // use the connection to open a channel to the service
+        IoFuture.Status status = IoFuture.Status.WAITING;
+        IoFuture<Channel> futureChannel = connection.openChannel("org.jboss.test", OptionMap.EMPTY);
+        try {
+            status = futureChannel.awaitInterruptibly(2L, TimeUnit.SECONDS);
+        } catch(InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        Logger.getLogger("TEST").infof("service returned status %s", status);
+        if (status == IoFuture.Status.DONE ) {
+            Logger.getLogger("TEST").infof("Channel creation succeeded");
+            sendChannel = futureChannel.get();
+            recvChannel = passer.getIoFuture().get();
+            assertNotNull(recvChannel);
+            assertNull("No SSLSession", recvChannel.getConnection().getSslSession());
+            if (!shouldSucceed)
+                fail("Channel creation succeeded when it should have failed!");
+        } else if (status == IoFuture.Status.FAILED) {
+            Exception exception = futureChannel.getException();
+            Logger.getLogger("TEST").infof("Channel creation failed with exception %s", exception);
+            if (shouldSucceed)
+                fail("Channel creation failed when it should have succeeded!");
+        }
+
+        // service has been tested, we can shut down
+        safeClose(sendChannel);
+        safeClose(recvChannel);
+        safeClose(connection);
+        serviceRegistration.close();
+    }
+
+}


### PR DESCRIPTION
This PR is the PR https://github.com/jboss-remoting/jboss-remoting/pull/239 which has been adjusted for the 5.0 branch.

For details, see: https://issues.redhat.com/browse/REM3-375

Added a test case to verify that the predicate does what is expected.