### PR TITLE
[REM3-377] Use safeClose() in ClientServiceHandle.close()

### DIFF
--- a/src/main/java/org/jboss/remoting3/ClientServiceHandle.java
+++ b/src/main/java/org/jboss/remoting3/ClientServiceHandle.java
@@ -141,6 +141,6 @@ public final class ClientServiceHandle<T> {
      * Close the channel associated with this handle
      */
     public void closeChannel() throws IOException {
-        channel.close();
+        safeClose(channel);
     }
 }


### PR DESCRIPTION
This PR does the following:

    adds use of safeClose() in ClientServiceHandle to prevent NPEs when shutting down the server

For more details: see https://issues.redhat.com/browse/REM3-377