### PR TITLE
[REM-381] Revert "REM3-378 Updated all classes with a dependency on deprecated Elytron …"

### DIFF
--- a/src/main/java/org/jboss/remoting3/ConnectionImpl.java
+++ b/src/main/java/org/jboss/remoting3/ConnectionImpl.java
@@ -35,7 +35,7 @@ import org.jboss.remoting3.spi.ConnectionHandlerFactory;
 import org.jboss.remoting3.spi.ConnectionProviderContext;
 import org.wildfly.common.Assert;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.ProtocolSaslServerFactory;

--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -72,7 +72,7 @@ import org.wildfly.security.auth.AuthenticationException;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.sasl.util.ProtocolSaslClientFactory;
 import org.wildfly.security.sasl.util.ServerNameSaslClientFactory;
 

--- a/src/main/java/org/jboss/remoting3/remote/HttpUpgradeConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/remote/HttpUpgradeConnectionProvider.java
@@ -39,7 +39,7 @@ import org.jboss.remoting3.spi.ConnectionProviderContext;
 import org.jboss.remoting3.spi.ExternalConnectionProvider;
 import org.wildfly.common.Assert;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.xnio.Cancellable;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
@@ -47,7 +47,7 @@ import org.jboss.remoting3.spi.NetworkServerProvider;
 import org.wildfly.common.Assert;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.xnio.Cancellable;
 import org.xnio.ChannelListener;
 import org.xnio.FutureResult;

--- a/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
@@ -43,7 +43,7 @@ import org.jboss.remoting3.RemotingOptions;
 import org.jboss.remoting3.Version;
 import org.jboss.remoting3.spi.ConnectionProviderContext;
 import org.wildfly.security.auth.principal.AnonymousPrincipal;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityIdentity;
 import org.wildfly.security.sasl.WildFlySasl;
 import org.wildfly.security.sasl.util.PropertiesSaslServerFactory;

--- a/src/main/java/org/jboss/remoting3/spi/ConnectionProviderContext.java
+++ b/src/main/java/org/jboss/remoting3/spi/ConnectionProviderContext.java
@@ -20,7 +20,7 @@ package org.jboss.remoting3.spi;
 
 import java.util.concurrent.Executor;
 import org.jboss.remoting3.Endpoint;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.xnio.Xnio;
 import org.xnio.XnioWorker;
 

--- a/src/main/java/org/jboss/remoting3/spi/ExternalConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/spi/ExternalConnectionProvider.java
@@ -21,7 +21,7 @@ package org.jboss.remoting3.spi;
 import java.io.IOException;
 import java.util.function.Consumer;
 
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.xnio.OptionMap;
 import org.xnio.StreamConnection;
 

--- a/src/main/java/org/jboss/remoting3/spi/NetworkServerProvider.java
+++ b/src/main/java/org/jboss/remoting3/spi/NetworkServerProvider.java
@@ -23,7 +23,7 @@ import java.net.SocketAddress;
 
 import javax.net.ssl.SSLContext;
 
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.xnio.OptionMap;
 import org.xnio.StreamConnection;
 import org.xnio.channels.AcceptingChannel;

--- a/src/test/java/org/jboss/remoting3/remote/HeartbeatTestCase.java
+++ b/src/test/java/org/jboss/remoting3/remote/HeartbeatTestCase.java
@@ -56,7 +56,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;

--- a/src/test/java/org/jboss/remoting3/test/ConnectionCloseTestCase.java
+++ b/src/test/java/org/jboss/remoting3/test/ConnectionCloseTestCase.java
@@ -51,7 +51,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;

--- a/src/test/java/org/jboss/remoting3/test/ConnectionTestCase.java
+++ b/src/test/java/org/jboss/remoting3/test/ConnectionTestCase.java
@@ -63,7 +63,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;

--- a/src/test/java/org/jboss/remoting3/test/OutboundMessageCountTestCase.java
+++ b/src/test/java/org/jboss/remoting3/test/OutboundMessageCountTestCase.java
@@ -62,7 +62,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;

--- a/src/test/java/org/jboss/remoting3/test/RemoteChannelCloseTest.java
+++ b/src/test/java/org/jboss/remoting3/test/RemoteChannelCloseTest.java
@@ -55,7 +55,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;

--- a/src/test/java/org/jboss/remoting3/test/RemoteChannelTest.java
+++ b/src/test/java/org/jboss/remoting3/test/RemoteChannelTest.java
@@ -51,7 +51,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;

--- a/src/test/java/org/jboss/remoting3/test/RemoteSslChannelTest.java
+++ b/src/test/java/org/jboss/remoting3/test/RemoteSslChannelTest.java
@@ -49,7 +49,7 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.MatchRule;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;

--- a/src/test/java/org/jboss/remoting3/test/racecondition/CloseConnectingEndpointTestCase.java
+++ b/src/test/java/org/jboss/remoting3/test/racecondition/CloseConnectingEndpointTestCase.java
@@ -48,7 +48,7 @@ import org.junit.runner.RunWith;
 import org.wildfly.security.WildFlyElytronProvider;
 import org.wildfly.security.auth.realm.SimpleMapBackedSecurityRealm;
 import org.wildfly.security.auth.server.MechanismConfiguration;
-import org.wildfly.security.auth.server.sasl.SaslAuthenticationFactory;
+import org.wildfly.security.auth.server.SaslAuthenticationFactory;
 import org.wildfly.security.auth.server.SecurityDomain;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.spec.ClearPasswordSpec;


### PR DESCRIPTION
Reverts jboss-remoting/jboss-remoting#252

The reason is that this commit alters public classes in Remoting, it should not go in a minor release, adding it to 5.0 was a mistake.
Jira: https://issues.redhat.com/browse/REM3-381