### PR TITLE
[REM3-383] ensure that counter is incremented on channel.writeMessage() IOException

### DIFF
--- a/src/main/java/org/jboss/remoting3/util/MessageTracker.java
+++ b/src/main/java/org/jboss/remoting3/util/MessageTracker.java
@@ -61,7 +61,7 @@ public final class MessageTracker {
             }
             this.counter = counter - 1;
         }
-        return getMessageInstance(channel.writeMessage());
+        return getMessageInstance(writeMessage());
     }
 
     /**
@@ -87,9 +87,22 @@ public final class MessageTracker {
                 }
                 this.counter = counter - 1;
             }
-            return getMessageInstance(channel.writeMessage());
+            return getMessageInstance(writeMessage());
         } finally {
             if (intr) Thread.currentThread().interrupt();
+        }
+    }
+
+    private MessageOutputStream writeMessage() throws IOException {
+        try {
+            return channel.writeMessage();
+        } catch (IOException e) {
+            final Object lock = this.lock;
+            synchronized (lock) {
+                this.counter ++;
+                lock.notify();
+            }
+            throw e;
         }
     }
 


### PR DESCRIPTION
the org.jboss.remoting3.util.MessageTracker counter is not decremented whenever there is an IoException within channel.writeMessage().

eventually no permit is available (counter == 0 ) but no one is using it.

as consequence all threads used to send messages will be blocked waiting for a permit that will never be available