### PR TITLE
[REM3-388][REM3-387] At OutboundMessage.bufferWriter.accept(), move the message…

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/OutboundMessage.java
+++ b/src/main/java/org/jboss/remoting3/remote/OutboundMessage.java
@@ -44,7 +44,7 @@ final class OutboundMessage extends MessageOutputStream {
     final RemoteConnectionChannel channel;
     final BufferPipeOutputStream pipeOutputStream;
     final int maximumWindow;
-    final int ackTimeout;
+    final long ackTimeout;
     int window;
     boolean closeCalled;
     boolean closeReceived;
@@ -115,7 +115,7 @@ final class OutboundMessage extends MessageOutputStream {
                         }
                         try {
                             log.tracef("Outbound message ID %04x: message window is closed, waiting", getActualId());
-                            pipeOutputStream.wait(ackTimeout, 0);
+                            pipeOutputStream.wait(ackTimeout/1_000_000, (int) ackTimeout % 1_000_000);
                             if (window == currentWindow) {
                                 // no changes, throw an exception
                                 timeoutExpired = true;
@@ -182,7 +182,7 @@ final class OutboundMessage extends MessageOutputStream {
 
     static final ToIntFunction<OutboundMessage> INDEXER = OutboundMessage::getActualId;
 
-    OutboundMessage(final short messageId, final RemoteConnectionChannel channel, final int window, final long maxOutboundMessageSize, final int ackTimeout) {
+    OutboundMessage(final short messageId, final RemoteConnectionChannel channel, final int window, final long maxOutboundMessageSize, final long ackTimeout) {
         this.messageId = messageId;
         this.channel = channel;
         this.window = maximumWindow = window;

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionChannel.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionChannel.java
@@ -71,7 +71,7 @@ final class RemoteConnectionChannel extends AbstractHandleableCloseable<Channel>
     private final int maxInboundMessages;
     private final long maxOutboundMessageSize;
     private final long maxInboundMessageSize;
-    private final int messageAckTimeout;
+    private final long messageAckTimeout;
     private volatile int channelState = 0;
 
     private static final AtomicIntegerFieldUpdater<RemoteConnectionChannel> channelStateUpdater = AtomicIntegerFieldUpdater.newUpdater(RemoteConnectionChannel.class, "channelState");
@@ -85,7 +85,7 @@ final class RemoteConnectionChannel extends AbstractHandleableCloseable<Channel>
     private static final int INBOUND_MESSAGES_MASK = ((1 << 30) - 1) & ~OUTBOUND_MESSAGES_MASK;
     private static final int ONE_INBOUND_MESSAGE = (1 << 15);
 
-    RemoteConnectionChannel(final RemoteConnectionHandler connectionHandler, final RemoteConnection connection, final int channelId, final int outboundWindow, final int inboundWindow, final int maxOutboundMessages, final int maxInboundMessages, final long maxOutboundMessageSize, final long maxInboundMessageSize, final int messageAckTimeout) {
+    RemoteConnectionChannel(final RemoteConnectionHandler connectionHandler, final RemoteConnection connection, final int channelId, final int outboundWindow, final int inboundWindow, final int maxOutboundMessages, final int maxInboundMessages, final long maxOutboundMessageSize, final long maxInboundMessageSize, final long messageAckTimeout) {
         super(connectionHandler.getConnectionContext().getConnectionProviderContext().getExecutor(), true);
         this.maxOutboundMessageSize = maxOutboundMessageSize;
         this.maxInboundMessageSize = maxInboundMessageSize;

--- a/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteReadListener.java
@@ -50,7 +50,7 @@ import static org.jboss.remoting3._private.Messages.log;
  */
 final class RemoteReadListener implements ChannelListener<ConduitStreamSourceChannel> {
     // FIXME temporarily using a system property as a solution to ACK TIMEOUT issue until an RFE is properly submitted
-    private static final int MESSAGE_ACK_TIMEOUT = Integer.parseInt(WildFlySecurityManager.getPropertyPrivileged("org.jboss.remoting3.remote.message.ack.timeout", String.valueOf(RemotingOptions.DEFAULT_MESSAGE_ACK_TIMEOUT)));
+    private static final long MESSAGE_ACK_TIMEOUT = Long.parseLong(WildFlySecurityManager.getPropertyPrivileged("org.jboss.remoting3.remote.message.ack.timeout", String.valueOf(RemotingOptions.DEFAULT_MESSAGE_ACK_TIMEOUT))) * 1_000_000;
 
     private static final byte[] NO_BYTES = new byte[0];
     private final RemoteConnectionHandler handler;


### PR DESCRIPTION
… ack timeout wait to a loop to protect against spurious wakes. Plus, check for other causes for being awakened before assuming the message ack timeout has expired.

The other causes for being awaked are all points where notifyAll was invoked. So, we need to check for closeReceived, closeCalled & !eof, and cancelSent before checking if the timeout expired withou a message ack

Jiras: https://issues.redhat.com/browse/REM3-387
          https://issues.redhat.com/browse/REM3-388