### PR TITLE
[REM3-389] EndpointImpl: Modify creation options of remote+tls connec…

### DIFF
--- a/src/main/java/org/jboss/remoting3/EndpointImpl.java
+++ b/src/main/java/org/jboss/remoting3/EndpointImpl.java
@@ -293,7 +293,7 @@ final class EndpointImpl extends AbstractHandleableCloseable<Endpoint> implement
             // remote (SSL is explicit in URL)
             final RemoteConnectionProviderFactory remoteConnectionProviderFactory = new RemoteConnectionProviderFactory();
             endpoint.addConnectionProvider("remote", remoteConnectionProviderFactory, OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE, Options.SSL_STARTTLS, Boolean.TRUE));
-            endpoint.addConnectionProvider("remote+tls", remoteConnectionProviderFactory, OptionMap.create(Options.SECURE, Boolean.TRUE));
+            endpoint.addConnectionProvider("remote+tls", remoteConnectionProviderFactory, OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE, Options.SSL_STARTTLS, Boolean.TRUE));
             // old (SSL is config-based)
             endpoint.addConnectionProvider("remoting", remoteConnectionProviderFactory, OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE, Options.SSL_STARTTLS, Boolean.TRUE));
             // http - SSL is handled by the HTTP layer


### PR DESCRIPTION
…tion provider

When trying to configure SSL connection using "remote+tls" protocol I encounter a failure: it seems that the cleartext connection is being open. Changing the creation options to the ones equal to "remote" protocol fixes the issue. This makes sense as "remote" protocol can be used to create SSL connection as well.

@fl4via  could you please review?
Jira: https://issues.redhat.com/browse/REM3-389