### PR TITLE
[REM3-404] Prevent that new tasks are created by ServerConnectionOpen…

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
+++ b/src/main/java/org/jboss/remoting3/remote/ServerConnectionOpenListener.java
@@ -92,6 +92,8 @@ final class ServerConnectionOpenListener  implements ChannelListener<ConduitStre
 
 
     public void handleEvent(final ConduitStreamSourceChannel channel) {
+        if (!connection.getConnection().isOpen())
+            return;
         final Pooled<ByteBuffer> pooled = connection.allocate();
         boolean ok = false;
         try {


### PR DESCRIPTION
…Listener.handleEvent in case the connection has been permaturely closed.
Jira: https://issues.redhat.com/browse/REM3-404

main PR: #290 