### PR TITLE
[REM3-413] Properly treat the scenario where a connection is pre auth…

### DIFF
--- a/src/main/java/org/jboss/remoting3/remote/HttpUpgradeConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/remote/HttpUpgradeConnectionProvider.java
@@ -266,6 +266,7 @@ final class HttpUpgradeConnectionProvider extends RemoteConnectionProvider {
             final RemoteConnection connection = new RemoteConnection(channel, sslChannel, optionMap, HttpUpgradeConnectionProvider.this);
             final ServerConnectionOpenListener openListener = new ServerConnectionOpenListener(connection, getConnectionProviderContext(), saslAuthenticationFactory, optionMap);
             channel.getSinkChannel().setWriteListener(connection.getWriteListener());
+            channel.getSinkChannel().setCloseListener(c -> connection.getWriteListener().shutdownWrites());
             conn.tracef("Accepted connection from %s to %s", channel.getPeerAddress(), channel.getLocalAddress());
             openListener.handleEvent(channel.getSourceChannel());
         }

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
@@ -274,6 +274,10 @@ final class RemoteConnection {
         public void handleEvent(final ConduitStreamSinkChannel channel) {
             final ByteBuffer[] cachedArray = this.cachedArray;
             synchronized (queue) {
+                if (closed && !channel.isOpen()) {
+                    Messages.conn.trace("Skipping write event because write listener is in closed state and channel is not open");
+                    return;
+                }
                 Pooled<ByteBuffer> pooled;
                 final Queue<Pooled<ByteBuffer>> queue = this.queue;
                 try {

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnectionProvider.java
@@ -197,6 +197,7 @@ class RemoteConnectionProvider extends AbstractHandleableCloseable<ConnectionPro
                 if (connection.isOpen()) {
                     remoteConnection.setResult(cancellableResult);
                     connection.getSinkChannel().setWriteListener(remoteConnection.getWriteListener());
+                    connection.getSinkChannel().setCloseListener(channel -> remoteConnection.getWriteListener().shutdownWrites());
                     final ClientConnectionOpenListener openListener = new ClientConnectionOpenListener(destination, remoteConnection, connectionProviderContext, authenticationConfiguration, saslClientFactoryOperator, serverMechs, connectOptions);
                     openListener.handleEvent(connection.getSourceChannel());
                 }
@@ -414,6 +415,7 @@ class RemoteConnectionProvider extends AbstractHandleableCloseable<ConnectionPro
             final RemoteConnection connection = new RemoteConnection(accepted, sslChannel, serverOptionMap, RemoteConnectionProvider.this);
             final ServerConnectionOpenListener openListener = new ServerConnectionOpenListener(connection, connectionProviderContext, saslAuthenticationFactory, serverOptionMap);
             accepted.getSinkChannel().setWriteListener(connection.getWriteListener());
+            accepted.getSinkChannel().setCloseListener(channel -> connection.getWriteListener().shutdownWrites());
             log.tracef("Accepted connection from %s to %s", connection.getPeerAddress(), connection.getLocalAddress());
             openListener.handleEvent(accepted.getSourceChannel());
         }


### PR DESCRIPTION
… closed.

See RemoteConnection.handlePreAuthCloseRequest to fully understand the code path. The remote connection write listener needs to have shutdown writes invoked to be aware that the channel is closed, or else there is no linkage between the connection and the XNIO channels layer when the channel is closed at ServerConnectionOpenListener.Initial listener. To complete the fix, the very same remote connection write listener needs to skip the write attempt if the channel is closed, which will prevent an uneeded ClosedChannelException.

If wondering when this bug is hit, notice that the write listener can be invoked after the read listener has read -1 during the execution of XNIO NioSocketConduit.handleReady, as a result of a wake up operations call.

Jira: https://issues.redhat.com/browse/REM3-413
PR: #304 