### PR TITLE
Enabling testing on JDK25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: JBoss Remoting CI
 
 on:
   push:
-    branches: [ "main", "5.0", "5.1" ]
+    branches: [ "5.0", "5.1" ]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   schedule:
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 8, 11, 17, 21, 25 ]
         openjdk_impl: [ temurin, adopt-openj9 ]
         exclude:
           - os: macos-latest

--- a/pom.xml
+++ b/pom.xml
@@ -463,4 +463,26 @@
             </plugins>
         </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>jdk23</id>
+            <activation>
+                <jdk>[23,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <!-- SE 23+ requires explicit config to turn on annotation processing -->
+                                <arg>-proc:full</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
 - Turning on compiler annotation processing on JDK 23+
 - Adding JDK 25 to CI pipeline