### PR TITLE
[REM3-429] CVE-2026-15562 At MessageReader, avoid int overflow in the…

### DIFF
--- a/src/main/java/org/jboss/remoting3/_private/Messages.java
+++ b/src/main/java/org/jboss/remoting3/_private/Messages.java
@@ -143,4 +143,7 @@ public interface Messages extends BasicLogger {
 
     @Message(id = 309, value = "Authentication not supported for this peer")
     AuthenticationException authenticationNotSupported();
+
+    @Message(id = 310, value = "Inbound message size %d is bigger than max message size %d")
+    IOException inboundMessageSizeBiggerThanLimit(int messageSize, long maxMessageSize);
 }

--- a/src/main/java/org/jboss/remoting3/remote/MessageReader.java
+++ b/src/main/java/org/jboss/remoting3/remote/MessageReader.java
@@ -37,16 +37,20 @@ import org.xnio.conduits.ConduitStreamSourceChannel;
  */
 final class MessageReader {
 
+    private static final int INT_OVERFLOW_SIZE_LIMIT = Integer.MAX_VALUE - 4;
+
     private final ConduitStreamSourceChannel sourceChannel;
     private final ArrayDeque<ByteBuffer> queue = new ArrayDeque<>();
     private final Object lock;
     private final ByteBuffer[] array = new ByteBuffer[16];
+    private final long maxSize;
 
     static final Pooled<ByteBuffer> EOF_MARKER = Buffers.emptyPooledByteBuffer();
 
-    MessageReader(final ConduitStreamSourceChannel sourceChannel, final Object lock) {
+    MessageReader(final ConduitStreamSourceChannel sourceChannel, final Object lock, final long maxSize) {
         this.sourceChannel = sourceChannel;
         this.lock = lock;
+        this.maxSize = maxSize;
     }
 
     ConduitStreamSourceChannel getSourceChannel() {
@@ -60,14 +64,17 @@ final class MessageReader {
                 if (first != null) {
                     if (first.remaining() >= 4) {
                         int size = first.getInt(first.position());
-                        if (remaining(size + 4)) {
+                        if (remaining(size)) {
                             ByteBuffer message;
                             if (ByteBufferPool.MEDIUM_SIZE >= size) {
                                 message = ByteBufferPool.MEDIUM_HEAP.allocate();
                             } else if (ByteBufferPool.LARGE_SIZE >= size) {
                                 message = ByteBufferPool.LARGE_HEAP.allocate();
-                            } else {
+                            } else if (maxSize == -1 || maxSize >= size) {
+                                // allocate it if there is no max size at all, or if size is within the maxSize limit
                                 message = ByteBuffer.allocate(size);
+                            } else {
+                                throw conn.inboundMessageSizeBiggerThanLimit(size, maxSize);
                             }
                             first.getInt();
                             int cnt = 0;
@@ -164,7 +171,12 @@ final class MessageReader {
         }
     }
 
-    private boolean remaining(int cnt) {
+    private boolean remaining(int messageSize) {
+        if (messageSize > INT_OVERFLOW_SIZE_LIMIT) {
+            return false;
+        }
+        // add header to total size
+        final int cnt = messageSize + 4;
         int rem = 0;
         for (ByteBuffer buffer : queue) {
             rem += buffer.remaining();

--- a/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
+++ b/src/main/java/org/jboss/remoting3/remote/RemoteConnection.java
@@ -70,7 +70,8 @@ final class RemoteConnection {
 
     RemoteConnection(final StreamConnection connection, final SslChannel sslChannel, final OptionMap optionMap, final RemoteConnectionProvider remoteConnectionProvider) {
         this.connection = connection;
-        this.messageReader = new MessageReader(connection.getSourceChannel(), writeListener.queue);
+        final long maxInboundMessageSize = optionMap.get(RemotingOptions.MAX_INBOUND_MESSAGE_SIZE, RemotingOptions.DEFAULT_MAX_INBOUND_MESSAGE_SIZE);
+        this.messageReader = new MessageReader(connection.getSourceChannel(), writeListener.queue, maxInboundMessageSize);
         this.sslChannel = sslChannel;
         this.optionMap = optionMap;
         heartbeatInterval = optionMap.get(RemotingOptions.HEARTBEAT_INTERVAL, RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL);


### PR DESCRIPTION
… total message size calculation.

Also, receive the max inbound message size by constructor, so we can read the remoting options from RemoteConnection and make this configurable in the server. Finally, handle possible maxSize set to -1, which means unbounded.

Jira: https://redhat.atlassian.net/browse/REM3-429